### PR TITLE
fix: drop bytecode optimization to keep numpy import working in frozen build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ def build_exe():
         'packages': ["numpy", "pysolar", "wmi", "pytz", "paho.mqtt"],
         'excludes': ["tkinter", "unittest", "pydoc"],
         'include_files': [icon_path],
-        'optimize': 1
+        'optimize': 0,
     }
 
     cx_Freeze.setup(


### PR DESCRIPTION
## Summary

The `1.10.0` frozen exe crashes at startup with:

\`\`\`
RuntimeError: object already has a different docstring
\`\`\`

inside numpy's \`_core/overrides.py\` (the \`array_function_dispatch\` decorator). Triggered by importing \`pysolar\` → numpy at \`src/plugins/display_image_tuner/sun_strength_notifier.py\`. The cause is cx_Freeze's \`optimize=1\` setting interacting with how numpy 2.x captures docstrings on its dispatch decorator inside the frozen environment.

## Fix

Set \`optimize=0\` in \`setup.py\`'s \`build_exe\` options. No other behavioural impact (\`-O\` only stripped \`assert\`, which we don't rely on for control flow).

## Verified locally

Built \`SwissWindowsKnife.exe\` with the fix via \`./env/Scripts/python.exe setup.py exe\` and launched it — boots cleanly through the import chain that previously crashed:

- UserSettings loads from registry
- DisplayImageTunerPlugin and DeviceDisplayMapperPlugin start
- DDC/CI worker applies brightness without GUI freeze

## Release impact

\`fix:\` prefix → semantic-release patch bump → **1.10.1**.