### PR TITLE
feat: pick sun location from an OpenStreetMap map

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "requests==2.32.4",
     "paho.mqtt==2.1.0",
     "psutil==7.2.2",
+    "timezonefinder==8.2.2",
 ]
 
 [project.optional-dependencies]

--- a/src/plugins/display_image_tuner/location_picker.py
+++ b/src/plugins/display_image_tuner/location_picker.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QFile, QIODevice, QObject, QUrl, Signal, Slot
+from PySide6.QtWebChannel import QWebChannel
+from PySide6.QtWebEngineWidgets import QWebEngineView
+from PySide6.QtWidgets import QFormLayout, QLabel, QVBoxLayout, QWidget
+
+from timezonefinder import TimezoneFinder
+
+
+_QWEBCHANNEL_JS_PATH = ":/qtwebchannel/qwebchannel.js"
+_TILE_URL = "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+_LEAFLET_CSS = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+_LEAFLET_JS = "https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+
+_tz_finder: TimezoneFinder | None = None
+
+
+def coordinates_to_timezone(latitude: float, longitude: float) -> str | None:
+    """Resolve an IANA timezone name from coordinates, or None if no match."""
+    global _tz_finder
+    if _tz_finder is None:
+        _tz_finder = TimezoneFinder()
+    return _tz_finder.timezone_at(lat=latitude, lng=longitude)
+
+
+def _read_qwebchannel_js() -> str:
+    f = QFile(_QWEBCHANNEL_JS_PATH)
+    if not f.open(QIODevice.OpenModeFlag.ReadOnly | QIODevice.OpenModeFlag.Text):
+        raise RuntimeError(f"Could not open {_QWEBCHANNEL_JS_PATH}")
+    try:
+        return bytes(f.readAll()).decode("utf-8")
+    finally:
+        f.close()
+
+
+def _build_html(initial_lat: float, initial_lng: float, qwebchannel_js: str) -> str:
+    return f"""<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <link rel="stylesheet" href="{_LEAFLET_CSS}" />
+  <style>
+    html, body, #map {{ height: 100%; margin: 0; }}
+    #map {{ background: #1e1e1e; }}
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script>{qwebchannel_js}</script>
+  <script src="{_LEAFLET_JS}"></script>
+  <script>
+    const map = L.map('map').setView([{initial_lat}, {initial_lng}], 6);
+    L.tileLayer('{_TILE_URL}', {{
+      attribution: '&copy; OpenStreetMap contributors',
+      maxZoom: 18,
+    }}).addTo(map);
+    let marker = L.marker([{initial_lat}, {initial_lng}]).addTo(map);
+
+    new QWebChannel(qt.webChannelTransport, function(channel) {{
+      const bridge = channel.objects.bridge;
+      map.on('click', function(e) {{
+        marker.setLatLng(e.latlng);
+        bridge.set_coordinates(e.latlng.lat, e.latlng.lng);
+      }});
+    }});
+  </script>
+</body>
+</html>"""
+
+
+class _MapBridge(QObject):
+    coordinates_picked = Signal(float, float)
+
+    @Slot(float, float)
+    def set_coordinates(self, lat: float, lng: float) -> None:
+        self.coordinates_picked.emit(lat, lng)
+
+
+class LocationPickerWidget(QWidget):
+    """Interactive OpenStreetMap-backed coordinate + timezone picker.
+
+    Emits `location_changed(lat, lng, timezone)` when the user clicks a
+    new location on the map. `timezone` is the IANA name resolved from
+    the coordinates (empty string if no match).
+    """
+
+    location_changed = Signal(float, float, str)
+
+    def __init__(
+        self,
+        initial_lat: float,
+        initial_lng: float,
+        initial_timezone: str,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+
+        self._lat = float(initial_lat)
+        self._lng = float(initial_lng)
+        self._timezone = str(initial_timezone)
+
+        self._coords_label = QLabel(self._format_coords(self._lat, self._lng))
+        self._timezone_label = QLabel(self._timezone or "(unknown)")
+
+        self._view = QWebEngineView(self)
+        self._view.setMinimumHeight(360)
+
+        self._channel = QWebChannel(self._view.page())
+        self._bridge = _MapBridge(self)
+        self._bridge.coordinates_picked.connect(self._on_coordinates_picked)
+        self._channel.registerObject("bridge", self._bridge)
+        self._view.page().setWebChannel(self._channel)
+
+        html = _build_html(self._lat, self._lng, _read_qwebchannel_js())
+        self._view.setHtml(html, QUrl("https://maps.local/"))
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self._view, 1)
+        info = QFormLayout()
+        info.addRow("Coordinates:", self._coords_label)
+        info.addRow("Timezone:", self._timezone_label)
+        layout.addLayout(info)
+
+    def latitude(self) -> float:
+        return self._lat
+
+    def longitude(self) -> float:
+        return self._lng
+
+    def timezone(self) -> str:
+        return self._timezone
+
+    @Slot(float, float)
+    def _on_coordinates_picked(self, lat: float, lng: float) -> None:
+        self._lat = lat
+        self._lng = lng
+        self._timezone = coordinates_to_timezone(lat, lng) or ""
+        self._coords_label.setText(self._format_coords(lat, lng))
+        self._timezone_label.setText(self._timezone or "(unknown)")
+        self.location_changed.emit(lat, lng, self._timezone)
+
+    @staticmethod
+    def _format_coords(lat: float, lng: float) -> str:
+        return f"{lat:.5f}, {lng:.5f}"

--- a/src/plugins/display_image_tuner/sun_location_panel.py
+++ b/src/plugins/display_image_tuner/sun_location_panel.py
@@ -1,8 +1,9 @@
-from PySide6.QtWidgets import QFormLayout, QLineEdit, QMessageBox, QWidget
+from PySide6.QtWidgets import QMessageBox, QVBoxLayout, QWidget
 import pytz
 
 from ...base.config_panel import ConfigPanel
 from ...base.user_settings import UserSettings
+from .location_picker import LocationPickerWidget
 from .sun_strength_notifier import (
     DEFAULT_LATITUDE, DEFAULT_LONGITUDE, DEFAULT_TIMEZONE, SunStrengthNotifier,
 )
@@ -21,8 +22,6 @@ class SunLocationConfigPanel(ConfigPanel):
         self._sun_strength = sun_strength_notifier
         self._user_settings = UserSettings.instance()
 
-        layout = QFormLayout(self)
-
         try:
             latitude = float(self._user_settings.get('sun_latitude'))  # type: ignore[arg-type]
             longitude = float(self._user_settings.get('sun_longitude'))  # type: ignore[arg-type]
@@ -30,40 +29,34 @@ class SunLocationConfigPanel(ConfigPanel):
             latitude, longitude = DEFAULT_LATITUDE, DEFAULT_LONGITUDE
         timezone = str(self._user_settings.get('sun_timezone') or DEFAULT_TIMEZONE)
 
-        self.latitude_field = QLineEdit(str(latitude), self)
-        layout.addRow("Latitude:", self.latitude_field)
+        self.picker = LocationPickerWidget(latitude, longitude, timezone, self)
 
-        self.longitude_field = QLineEdit(str(longitude), self)
-        layout.addRow("Longitude:", self.longitude_field)
-
-        self.timezone_field = QLineEdit(timezone, self)
-        self.timezone_field.setPlaceholderText("e.g. Europe/Zurich")
-        layout.addRow("Timezone (IANA):", self.timezone_field)
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.picker)
 
     def apply(self) -> bool:
+        latitude = self.picker.latitude()
+        longitude = self.picker.longitude()
+        timezone = self.picker.timezone()
+
+        if not timezone:
+            QMessageBox.warning(
+                self, "Invalid input",
+                "No timezone could be resolved for the selected coordinates. "
+                "Pick a different point on the map.",
+            )
+            return False
         try:
-            latitude = float(self.latitude_field.text())
-            longitude = float(self.longitude_field.text())
-        except ValueError:
-            QMessageBox.warning(self, "Invalid input", "Latitude and longitude must be numeric.")
-            return False
-        if not -90.0 <= latitude <= 90.0:
-            QMessageBox.warning(self, "Invalid input", "Latitude must be between -90 and 90.")
-            return False
-        if not -180.0 <= longitude <= 180.0:
-            QMessageBox.warning(self, "Invalid input", "Longitude must be between -180 and 180.")
-            return False
-        try:
-            pytz.timezone(self.timezone_field.text())
+            pytz.timezone(timezone)
         except pytz.UnknownTimeZoneError:
             QMessageBox.warning(
                 self, "Invalid input",
-                f"Unknown IANA timezone: {self.timezone_field.text()!r}",
+                f"Unknown IANA timezone: {timezone!r}",
             )
             return False
 
         self._user_settings.set('sun_latitude', latitude)
         self._user_settings.set('sun_longitude', longitude)
-        self._user_settings.set('sun_timezone', self.timezone_field.text())
+        self._user_settings.set('sun_timezone', timezone)
         self._sun_strength.calculate_sun_strength()
         return True

--- a/tests/test_location_picker.py
+++ b/tests/test_location_picker.py
@@ -1,0 +1,19 @@
+from src.plugins.display_image_tuner.location_picker import coordinates_to_timezone
+
+
+def test_coordinates_to_timezone_resolves_known_city():
+    # Lausanne, Switzerland.
+    assert coordinates_to_timezone(46.521410, 6.632273) == "Europe/Zurich"
+
+
+def test_coordinates_to_timezone_resolves_paris():
+    assert coordinates_to_timezone(48.8566, 2.3522) == "Europe/Paris"
+
+
+def test_coordinates_to_timezone_returns_string_for_ocean_point():
+    # timezonefinder covers the globe including Etc/GMT bands over open
+    # ocean — we only need a non-empty result, exact value is implementation
+    # detail.
+    result = coordinates_to_timezone(-40.0, -30.0)
+    assert result is not None
+    assert result.startswith("Etc/")

--- a/tests/test_sun_location_panel.py
+++ b/tests/test_sun_location_panel.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 
@@ -18,52 +20,25 @@ def panel(qtbot, fake_user_settings, silent_messagebox):
     return p, sun
 
 
-def test_apply_persists_valid_input_and_recalculates(panel, fake_user_settings):
+def test_apply_persists_picked_coordinates_and_timezone(panel, fake_user_settings):
     p, sun = panel
-    p.latitude_field.setText("48.8")
-    p.longitude_field.setText("2.35")
-    p.timezone_field.setText("Europe/Paris")
+    p.picker._on_coordinates_picked(48.8566, 2.3522)  # Paris
 
     assert p.apply() is True
-    assert fake_user_settings.get('sun_latitude') == 48.8
-    assert fake_user_settings.get('sun_longitude') == 2.35
+    assert fake_user_settings.get('sun_latitude') == pytest.approx(48.8566)
+    assert fake_user_settings.get('sun_longitude') == pytest.approx(2.3522)
     assert fake_user_settings.get('sun_timezone') == "Europe/Paris"
     assert sun.recalc_count == 1
 
 
-def test_apply_rejects_non_numeric_lat_lon(panel, fake_user_settings):
+def test_apply_rejects_when_timezone_cannot_be_resolved(panel, fake_user_settings):
     p, sun = panel
-    p.latitude_field.setText("not-a-number")
-    p.longitude_field.setText("0")
-    p.timezone_field.setText("UTC")
-
-    assert p.apply() is False
-    assert sun.recalc_count == 0
-    assert fake_user_settings.get('sun_latitude') is None
-
-
-@pytest.mark.parametrize("lat,lon", [
-    ("100", "0"),     # latitude too high
-    ("-91", "0"),     # latitude too low
-    ("0", "181"),     # longitude too high
-    ("0", "-200"),    # longitude too low
-])
-def test_apply_rejects_out_of_range(panel, fake_user_settings, lat, lon):
-    p, sun = panel
-    p.latitude_field.setText(lat)
-    p.longitude_field.setText(lon)
-    p.timezone_field.setText("UTC")
-
-    assert p.apply() is False
-    assert sun.recalc_count == 0
-    assert fake_user_settings.get('sun_latitude') is None
-
-
-def test_apply_rejects_unknown_timezone(panel, fake_user_settings):
-    p, sun = panel
-    p.latitude_field.setText("0")
-    p.longitude_field.setText("0")
-    p.timezone_field.setText("Europe/NotARealCity")
+    # Mid-ocean point with no timezone polygon.
+    with patch(
+        'src.plugins.display_image_tuner.location_picker.coordinates_to_timezone',
+        return_value=None,
+    ):
+        p.picker._on_coordinates_picked(0.0, -30.0)
 
     assert p.apply() is False
     assert sun.recalc_count == 0
@@ -72,7 +47,6 @@ def test_apply_rejects_unknown_timezone(panel, fake_user_settings):
 
 def test_init_seeds_defaults_when_settings_empty(panel):
     p, _ = panel
-    # Defaults pulled from sun_strength_notifier
-    assert p.latitude_field.text() == "46.52141"
-    assert p.longitude_field.text() == "6.632273"
-    assert p.timezone_field.text() == "Europe/Zurich"
+    assert p.picker.latitude() == pytest.approx(46.52141)
+    assert p.picker.longitude() == pytest.approx(6.632273)
+    assert p.picker.timezone() == "Europe/Zurich"


### PR DESCRIPTION
## Summary

- Replaces the manual lat/lng/timezone fields on the Sun strength config tab with an interactive Leaflet map (via QtWebEngine + QWebChannel). Clicking anywhere on the map drops a marker, the IANA timezone is auto-resolved from the new coordinates with the \`timezonefinder\` library, and both are persisted on Apply.
- No manual coordinate or timezone input is allowed — the map is the only entry point. Coordinates and the resolved timezone show read-only beneath the map.
- Adds \`timezonefinder==8.2.2\` to runtime deps. Leaflet itself is loaded from \`unpkg\` over HTTPS and OSM tiles come from the public OpenStreetMap tile service, so opening the panel requires internet on first paint.

## Test plan

- [ ] Open Configuration → Sun strength. Map renders, marker sits at the existing saved coordinates.
- [ ] Click on the map at a different location. Marker moves, the read-only "Coordinates" and "Timezone" labels update to the new lat/lng and the matching IANA zone (e.g. clicking Paris → \`Europe/Paris\`, Tokyo → \`Asia/Tokyo\`).
- [ ] Click Apply. Reopen the dialog; the map opens at the freshly-saved coordinates.
- [ ] Behavior visible in the Display tuning tab's preview graph: sunrise/sunset markers reflect the new location.
- [ ] Verify the cx_Freeze installer build still works on this branch (QtWebEngine adds significant freeze surface — may need bundling tweaks, flag if so).