### PR TITLE
docs: rewrite README and surface tagline in About

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,56 @@
 # Swiss Windows Knife
 
-### What is it?
-A Swiss Windows Knife, kinda like a Swiss Army Knife but for Windows. 
-Let's be honest, it's my personal army knife for my Windows machines.
+A personal tray-app toolkit for taming Windows monitors, displays, and home-automation bridges. Single maintainer, single user — me — but the code is here in case you want to fork it.
 
-It does a bit of everything and nothing, here goes some:
-- automatically swap between monitors inputs (eg. from HDMI to DP) when a new mouse / keyboard is connected or disconnected;
-- changes brightness and contrast of monitors according to the monitors;
-- and much more..
+## What it does
 
-### Generate the installer
-The installer will be located under build/installer/SwissWindowsKnife-<version>.exe by using:
+Each feature is a plugin loaded by the tray. Toggle them on/off from the tray's **Plugins** menu; tune them from a unified **Configuration** dialog (tabbed).
+
+- **Display brightness & contrast (auto)** — pick a sun-anchored keyframe schedule (night level, day level, sunrise/sunset offsets, ramp duration, ramp smoothness) and the app drives every detected monitor over DDC/CI through the day. Live preview graph in the configuration panel, with a year-of-day scrubber to see how the curve shifts seasonally.
+- **Sun strength location** — coordinates and timezone are picked from an embedded OpenStreetMap (Leaflet via `QtWebEngine`); IANA timezone is auto-resolved from the chosen point with `timezonefinder`. No manual lat/lng/timezone fields.
+- **Display input switcher (USB-aware)** — when a configured USB device (e.g. a KVM-shared keyboard or mouse) connects or disconnects, swaps every monitor's input source over DDC/CI to the matching pair you configured per-display.
+- **Home Assistant MQTT publisher** — exposes host metrics (CPU usage / temperature / frequency, memory, disk free per drive, network rx/tx, uptime, monitor count, current user, foreground window, lock state, battery) as MQTT discovery entities, plus a few command entities (lock, sleep, shutdown). Per-entity publish toggles and intervals are configurable.
+- **Auto-updater** — checks the GitHub releases page on a 30-minute interval and on a manual click; prompts before downloading and silently runs the Inno Setup installer when accepted.
+- **Tray utilities** — log viewer, About dialog, Configuration dialog with tab persistence and remembered window sizes.
+
+## Install (just use the app)
+
+Grab the latest installer from [Releases](https://github.com/dbtdsilva/swiss-windows-knife/releases/latest) — it's a per-user Inno Setup `.exe`, no admin rights needed. The app then auto-updates itself when newer releases land.
+
+## Build from source
+
 ```sh
-python setup installer
+# clone, set up a venv at ./env/, then:
+./env/Scripts/python.exe -m pip install -e .[build,test]
+
+# run from source (no freeze)
+./env/Scripts/python.exe -m src.swiss_windows_knife
+
+# regenerate Qt resources after editing resources.qrc
+python setup.py resources
+
+# freeze with cx_Freeze
+python setup.py exe
+
+# package the Inno Setup installer (Windows only)
+python setup.py installer
 ```
-Alternatively, you can also check the releases on GitHub.
+
+`pre-commit install` once per clone wires the [ruff](https://github.com/astral-sh/ruff) lint hook the same way CI runs it.
+
+## Project layout
+
+| Path | What's there |
+| --- | --- |
+| `src/swiss_windows_knife.py` | Entry point — constructs `QApplication` and `TrayWidget`. |
+| `src/ui/` | Tray widget, configuration dialog, log viewer, About dialog. |
+| `src/base/` | Reusable infrastructure: `BaseWidget`, `ConfigPanel`, `UserSettings`, `PersistentSizeDialog`, the DDC/CI `monitor_runner`. |
+| `src/plugins/` | One package per plugin (display tuner, device-display mapper, Home Assistant MQTT). |
+| `src/components/update_checker.py` | The auto-updater. |
+| `tests/` | `pytest` + `pytest-qt`, headless via `QT_QPA_PLATFORM=offscreen`. |
+
+More project conventions (commit tags, monitor runner rules, settings storage) live in [`CLAUDE.md`](CLAUDE.md).
+
+## License
+
+[MIT](https://github.com/dbtdsilva/swiss-windows-knife/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,56 +1,140 @@
+<div align="center">
+
+<img src="icons/coat-of-arms.png" alt="Swiss Windows Knife" width="96" />
+
 # Swiss Windows Knife
 
-A personal tray-app toolkit for taming Windows monitors, displays, and home-automation bridges. Single maintainer, single user — me — but the code is here in case you want to fork it.
+**A personal Windows tray-app toolkit:** adaptive monitor brightness/contrast, USB-aware display input switching, Home Assistant MQTT bridge, and more.
 
-## What it does
+[**Releases**](https://github.com/dbtdsilva/swiss-windows-knife/releases/latest) &nbsp;·&nbsp; [**Changelog**](CHANGELOG.md) &nbsp;·&nbsp; [**Conventions**](CLAUDE.md)
 
-Each feature is a plugin loaded by the tray. Toggle them on/off from the tray's **Plugins** menu; tune them from a unified **Configuration** dialog (tabbed).
+[![Build and test](https://github.com/dbtdsilva/swiss-windows-knife/actions/workflows/build-n-test.yml/badge.svg)](https://github.com/dbtdsilva/swiss-windows-knife/actions/workflows/build-n-test.yml)
+[![Latest release](https://img.shields.io/github/v/release/dbtdsilva/swiss-windows-knife?label=release&sort=semver&color=blue)](https://github.com/dbtdsilva/swiss-windows-knife/releases/latest)
+[![Python](https://img.shields.io/badge/python-3.12%2B-blue.svg)](https://www.python.org/downloads/)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-- **Display brightness & contrast (auto)** — pick a sun-anchored keyframe schedule (night level, day level, sunrise/sunset offsets, ramp duration, ramp smoothness) and the app drives every detected monitor over DDC/CI through the day. Live preview graph in the configuration panel, with a year-of-day scrubber to see how the curve shifts seasonally.
-- **Sun strength location** — coordinates and timezone are picked from an embedded OpenStreetMap (Leaflet via `QtWebEngine`); IANA timezone is auto-resolved from the chosen point with `timezonefinder`. No manual lat/lng/timezone fields.
-- **Display input switcher (USB-aware)** — when a configured USB device (e.g. a KVM-shared keyboard or mouse) connects or disconnects, swaps every monitor's input source over DDC/CI to the matching pair you configured per-display.
-- **Home Assistant MQTT publisher** — exposes host metrics (CPU usage / temperature / frequency, memory, disk free per drive, network rx/tx, uptime, monitor count, current user, foreground window, lock state, battery) as MQTT discovery entities, plus a few command entities (lock, sleep, shutdown). Per-entity publish toggles and intervals are configurable.
-- **Auto-updater** — checks the GitHub releases page on a 30-minute interval and on a manual click; prompts before downloading and silently runs the Inno Setup installer when accepted.
-- **Tray utilities** — log viewer, About dialog, Configuration dialog with tab persistence and remembered window sizes.
+</div>
 
-## Install (just use the app)
+---
 
-Grab the latest installer from [Releases](https://github.com/dbtdsilva/swiss-windows-knife/releases/latest) — it's a per-user Inno Setup `.exe`, no admin rights needed. The app then auto-updates itself when newer releases land.
+- 🌅 &nbsp;**Adaptive brightness & contrast** anchored to real sunrise/sunset, with a live preview graph
+- 🗺️ &nbsp;**OpenStreetMap** location picker — coordinates and IANA timezone resolved from a single map click
+- 🔌 &nbsp;**USB-aware display switching** — flips monitor inputs over DDC/CI when a KVM device hops machines
+- 🏠 &nbsp;**Home Assistant MQTT** publisher exposing host metrics + lock / sleep / shutdown commands
+- ⬆️ &nbsp;**Built-in auto-updater** that picks up new releases from GitHub and re-installs silently
+- 🪟 &nbsp;**Native Windows tray** with a unified tabbed configuration dialog and remembered window sizes
+
+## Table of contents
+
+- [Installation](#installation)
+- [Features](#features)
+- [Build from source](#build-from-source)
+- [Project layout](#project-layout)
+- [Releases](#releases)
+- [License](#license)
+
+## Installation
+
+Grab the latest installer from the [releases page](https://github.com/dbtdsilva/swiss-windows-knife/releases/latest) and run it — it's a per-user Inno Setup `.exe` and does not need administrator rights. Once installed, the application keeps itself up-to-date through the built-in auto-updater.
+
+## Features
+
+Each capability ships as an isolated plugin loaded by the tray on start-up. Toggle plugins on or off from **Plugins** in the tray menu, and tune them from a unified, tabbed **Configuration…** dialog.
+
+<details>
+<summary><strong>🌅 Adaptive monitor brightness &amp; contrast</strong></summary>
+
+A keyframe-based schedule anchored to your local sunrise and sunset — define a *night level*, *day level*, *sunrise / sunset offsets*, *ramp duration*, and *ramp smoothness* (ease-in / linear / ease-out) per axis. The plugin drives every detected monitor over **DDC/CI** and renders a live preview graph in the configuration panel, with a year-of-day scrubber so you can see how the curve shifts seasonally before committing.
+
+Each axis (brightness, contrast) can be independently set to **Auto** or pinned to a fixed value from the tray menu. Auto-mode reflects in the preview graph as a flat line, fixed-mode as the eased schedule.
+</details>
+
+<details>
+<summary><strong>🗺️ OpenStreetMap location picker</strong></summary>
+
+Coordinates and timezone are picked from an embedded **Leaflet** map (rendered through `QtWebEngine`); the IANA timezone is auto-resolved from the chosen point with [`timezonefinder`](https://github.com/jannikmi/timezonefinder). No manual lat/lng or timezone entry — drop a pin, click OK, done.
+</details>
+
+<details>
+<summary><strong>🔌 USB-aware display input switching</strong></summary>
+
+Listens for a configured USB device — typically a keyboard, mouse, or other peripheral shared by a KVM — and, when it connects or disconnects, swaps every monitor's input source over DDC/CI to the matching pair you configured per display. Handy for one-keyboard-many-machines setups.
+</details>
+
+<details>
+<summary><strong>🏠 Home Assistant MQTT publisher</strong></summary>
+
+Publishes host metrics as MQTT discovery entities so they appear in Home Assistant without manual YAML:
+
+- CPU usage / temperature / frequency
+- Memory usage
+- Per-drive disk free
+- Network rx / tx
+- Uptime, monitor count, current user, foreground window, lock state, battery state
+
+A small set of command entities (lock, sleep, shutdown) lets Home Assistant trigger the host. Per-entity publish toggles and per-entity intervals are configurable.
+</details>
+
+<details>
+<summary><strong>⬆️ Auto-updater</strong></summary>
+
+Checks the GitHub releases endpoint every 30 minutes and on demand. When a newer version is found it prompts the user, downloads the Inno Setup installer to a temp folder, and runs it silently with a post-install relaunch.
+</details>
+
+<details>
+<summary><strong>🪟 Tray utilities</strong></summary>
+
+Live log viewer with adjustable verbosity, About dialog with version + license + project URL, and a unified configuration dialog that auto-tabs each plugin's panel and remembers its window size between sessions.
+</details>
 
 ## Build from source
 
+The project pins **Python 3.12** and uses a virtual environment at `./env/`. From a fresh clone:
+
 ```sh
-# clone, set up a venv at ./env/, then:
+# install runtime, build, and test dependencies
 ./env/Scripts/python.exe -m pip install -e .[build,test]
 
-# run from source (no freeze)
+# run the tray straight from source (no freeze)
 ./env/Scripts/python.exe -m src.swiss_windows_knife
 
 # regenerate Qt resources after editing resources.qrc
 python setup.py resources
 
-# freeze with cx_Freeze
+# freeze the executable with cx_Freeze
 python setup.py exe
 
 # package the Inno Setup installer (Windows only)
 python setup.py installer
 ```
 
-`pre-commit install` once per clone wires the [ruff](https://github.com/astral-sh/ruff) lint hook the same way CI runs it.
+Wire the same lint hook CI uses:
+
+```sh
+pip install pre-commit
+pre-commit install   # runs ruff on staged files before each commit
+```
 
 ## Project layout
 
-| Path | What's there |
+| Path | Responsibility |
 | --- | --- |
 | `src/swiss_windows_knife.py` | Entry point — constructs `QApplication` and `TrayWidget`. |
 | `src/ui/` | Tray widget, configuration dialog, log viewer, About dialog. |
 | `src/base/` | Reusable infrastructure: `BaseWidget`, `ConfigPanel`, `UserSettings`, `PersistentSizeDialog`, the DDC/CI `monitor_runner`. |
-| `src/plugins/` | One package per plugin (display tuner, device-display mapper, Home Assistant MQTT). |
-| `src/components/update_checker.py` | The auto-updater. |
-| `tests/` | `pytest` + `pytest-qt`, headless via `QT_QPA_PLATFORM=offscreen`. |
+| `src/plugins/display_image_tuner/` | Adaptive brightness/contrast plugin and OSM location picker. |
+| `src/plugins/device_display_mapper/` | USB-aware display input switcher. |
+| `src/plugins/home_assistant_mqtt_pub/` | Home Assistant MQTT publisher and command entities. |
+| `src/components/update_checker.py` | Auto-updater. |
+| `tests/` | `pytest` + `pytest-qt`, run headless with `QT_QPA_PLATFORM=offscreen`. |
 
-More project conventions (commit tags, monitor runner rules, settings storage) live in [`CLAUDE.md`](CLAUDE.md).
+Deeper conventions (commit tags, monitor-runner usage rules, settings storage) live in [`CLAUDE.md`](CLAUDE.md).
+
+## Releases
+
+Releases follow [semantic versioning](https://semver.org/) and are cut automatically by [`python-semantic-release`](https://github.com/python-semantic-release/python-semantic-release) from [conventional commit](https://www.conventionalcommits.org/) messages on `main`. Each release publishes the Inno Setup installer as an asset and the changelog body is generated from the commit history.
 
 ## License
 
-[MIT](https://github.com/dbtdsilva/swiss-windows-knife/blob/main/LICENSE).
+Released under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -25,68 +25,9 @@
 - ⬆️ &nbsp;**Built-in auto-updater** that picks up new releases from GitHub and re-installs silently
 - 🪟 &nbsp;**Native Windows tray** with a unified tabbed configuration dialog and remembered window sizes
 
-## Table of contents
-
-- [Installation](#installation)
-- [Features](#features)
-- [Build from source](#build-from-source)
-- [Project layout](#project-layout)
-- [Releases](#releases)
-- [License](#license)
-
 ## Installation
 
 Grab the latest installer from the [releases page](https://github.com/dbtdsilva/swiss-windows-knife/releases/latest) and run it — it's a per-user Inno Setup `.exe` and does not need administrator rights. Once installed, the application keeps itself up-to-date through the built-in auto-updater.
-
-## Features
-
-Each capability ships as an isolated plugin loaded by the tray on start-up. Toggle plugins on or off from **Plugins** in the tray menu, and tune them from a unified, tabbed **Configuration…** dialog.
-
-<details>
-<summary><strong>🌅 Adaptive monitor brightness &amp; contrast</strong></summary>
-
-A keyframe-based schedule anchored to your local sunrise and sunset — define a *night level*, *day level*, *sunrise / sunset offsets*, *ramp duration*, and *ramp smoothness* (ease-in / linear / ease-out) per axis. The plugin drives every detected monitor over **DDC/CI** and renders a live preview graph in the configuration panel, with a year-of-day scrubber so you can see how the curve shifts seasonally before committing.
-
-Each axis (brightness, contrast) can be independently set to **Auto** or pinned to a fixed value from the tray menu. Auto-mode reflects in the preview graph as a flat line, fixed-mode as the eased schedule.
-</details>
-
-<details>
-<summary><strong>🗺️ OpenStreetMap location picker</strong></summary>
-
-Coordinates and timezone are picked from an embedded **Leaflet** map (rendered through `QtWebEngine`); the IANA timezone is auto-resolved from the chosen point with [`timezonefinder`](https://github.com/jannikmi/timezonefinder). No manual lat/lng or timezone entry — drop a pin, click OK, done.
-</details>
-
-<details>
-<summary><strong>🔌 USB-aware display input switching</strong></summary>
-
-Listens for a configured USB device — typically a keyboard, mouse, or other peripheral shared by a KVM — and, when it connects or disconnects, swaps every monitor's input source over DDC/CI to the matching pair you configured per display. Handy for one-keyboard-many-machines setups.
-</details>
-
-<details>
-<summary><strong>🏠 Home Assistant MQTT publisher</strong></summary>
-
-Publishes host metrics as MQTT discovery entities so they appear in Home Assistant without manual YAML:
-
-- CPU usage / temperature / frequency
-- Memory usage
-- Per-drive disk free
-- Network rx / tx
-- Uptime, monitor count, current user, foreground window, lock state, battery state
-
-A small set of command entities (lock, sleep, shutdown) lets Home Assistant trigger the host. Per-entity publish toggles and per-entity intervals are configurable.
-</details>
-
-<details>
-<summary><strong>⬆️ Auto-updater</strong></summary>
-
-Checks the GitHub releases endpoint every 30 minutes and on demand. When a newer version is found it prompts the user, downloads the Inno Setup installer to a temp folder, and runs it silently with a post-install relaunch.
-</details>
-
-<details>
-<summary><strong>🪟 Tray utilities</strong></summary>
-
-Live log viewer with adjustable verbosity, About dialog with version + license + project URL, and a unified configuration dialog that auto-tabs each plugin's panel and remembers its window size between sessions.
-</details>
 
 ## Build from source
 
@@ -115,21 +56,6 @@ Wire the same lint hook CI uses:
 pip install pre-commit
 pre-commit install   # runs ruff on staged files before each commit
 ```
-
-## Project layout
-
-| Path | Responsibility |
-| --- | --- |
-| `src/swiss_windows_knife.py` | Entry point — constructs `QApplication` and `TrayWidget`. |
-| `src/ui/` | Tray widget, configuration dialog, log viewer, About dialog. |
-| `src/base/` | Reusable infrastructure: `BaseWidget`, `ConfigPanel`, `UserSettings`, `PersistentSizeDialog`, the DDC/CI `monitor_runner`. |
-| `src/plugins/display_image_tuner/` | Adaptive brightness/contrast plugin and OSM location picker. |
-| `src/plugins/device_display_mapper/` | USB-aware display input switcher. |
-| `src/plugins/home_assistant_mqtt_pub/` | Home Assistant MQTT publisher and command entities. |
-| `src/components/update_checker.py` | Auto-updater. |
-| `tests/` | `pytest` + `pytest-qt`, run headless with `QT_QPA_PLATFORM=offscreen`. |
-
-Deeper conventions (commit tags, monitor-runner usage rules, settings storage) live in [`CLAUDE.md`](CLAUDE.md).
 
 ## Releases
 

--- a/src/app_info.py
+++ b/src/app_info.py
@@ -4,6 +4,7 @@ __version__ = "1.12.0"
 
 _AppInfo = namedtuple("AppInfo", [
     'APP_NAME',
+    'APP_TAGLINE',
     'APP_AUTHOR',
     'APP_PUBLISHER',
     'APP_URL',
@@ -13,6 +14,7 @@ _AppInfo = namedtuple("AppInfo", [
 
 APP_INFO = _AppInfo(
     APP_NAME="Swiss Windows Knife",
+    APP_TAGLINE="A personal tray-app toolkit for taming Windows monitors, displays, and home-automation bridges.",
     APP_AUTHOR="Diogo Silva",
     APP_PUBLISHER="Diogo Silva",
     APP_URL="https://github.com/dbtdsilva/swiss-windows-knife",

--- a/src/ui/about_dialog.py
+++ b/src/ui/about_dialog.py
@@ -23,11 +23,13 @@ class AboutDialog(QDialog):
 
         info_label = QLabel(
             f"<h2 style='margin:0'>{APP_INFO.APP_NAME}</h2>"
+            f"<p style='color:gray;margin:4px 24px'>{APP_INFO.APP_TAGLINE}</p>"
             f"<p>Version {APP_INFO.APP_VERSION}</p>"
             f"<p>{APP_INFO.APP_AUTHOR}<br>"
             f"Released under the {APP_INFO.APP_LICENSE} License</p>"
             f"<p><a href='{APP_INFO.APP_URL}'>{APP_INFO.APP_URL}</a></p>"
         )
+        info_label.setWordWrap(True)
         info_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
         info_label.setTextFormat(Qt.TextFormat.RichText)
         info_label.setOpenExternalLinks(True)


### PR DESCRIPTION
## Summary

- README was a 4-line stub with an outdated build command (`python setup installer`). Rewrites it as a current-state overview: tagline, the five active plugins (display tuner / OSM location picker / USB display switcher / Home Assistant MQTT / auto-updater), install instructions for end users (release exe), build-from-source steps with the actual `setup.py` modes, project layout table, and a pointer to `CLAUDE.md` for the deeper conventions.
- Adds `APP_TAGLINE` to `AppInfo` and renders it under the app name in the About dialog (single grey line, word-wrapped).

## Test plan

- [x] `ruff check .` clean.
- [x] `pytest tests/` — 151 passed.
- [x] About dialog renders under offscreen Qt (`478×291`).
- [x] Open About in the live tray and confirm the tagline reads sensibly.