### PR TITLE
fix: keep auto-updater unstuck when the worker hits an unexpected error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def build_exe():
 
     build_options = {
         'silent': 2,
-        'packages': ["numpy", "pysolar", "wmi", "pytz", "paho.mqtt"],
+        'packages': ["numpy", "pysolar", "wmi", "pytz", "paho.mqtt", "requests"],
         'excludes': ["tkinter", "unittest", "pydoc"],
         'include_files': [icon_path],
         'optimize': 0,

--- a/src/components/update_checker.py
+++ b/src/components/update_checker.py
@@ -38,28 +38,34 @@ class _CheckWorker(QObject):
 
     @Slot()
     def run(self) -> None:
+        # `finished` MUST be emitted on every exit path so that the caller's
+        # `_busy` flag is cleared. We catch a broad Exception (rather than only
+        # `requests.RequestException` / `ValueError`) because frozen builds
+        # have surfaced unexpected error types from inside requests / urllib3
+        # / SSL — when one escaped this method, the worker thread died
+        # without emitting `finished`, leaving subsequent clicks silently
+        # no-oping for the lifetime of the process.
         try:
             response = requests.get(LATEST_RELEASE_URL, timeout=NETWORK_TIMEOUT_S)
             response.raise_for_status()
             data = response.json()
-        except (requests.RequestException, ValueError):
+
+            installer_url: str | None = None
+            for asset in data.get('assets', []):
+                name = asset.get('name', '')
+                if name.endswith('.exe') and 'browser_download_url' in asset:
+                    installer_url = asset['browser_download_url']
+                    break
+
+            if installer_url is None or 'tag_name' not in data:
+                logging.warning("No installer asset in latest release")
+                self.finished.emit(None)
+                return
+
+            self.finished.emit((data['tag_name'], installer_url))
+        except Exception:
             logging.exception("Failed to query for updates")
             self.finished.emit(None)
-            return
-
-        installer_url: str | None = None
-        for asset in data.get('assets', []):
-            name = asset.get('name', '')
-            if name.endswith('.exe') and 'browser_download_url' in asset:
-                installer_url = asset['browser_download_url']
-                break
-
-        if installer_url is None or 'tag_name' not in data:
-            logging.warning("No installer asset in latest release")
-            self.finished.emit(None)
-            return
-
-        self.finished.emit((data['tag_name'], installer_url))
 
 
 class _DownloadWorker(QObject):
@@ -79,12 +85,12 @@ class _DownloadWorker(QObject):
                 with open(path, 'wb') as f:
                     for chunk in r.iter_content(chunk_size=8192):
                         f.write(chunk)
-        except (requests.RequestException, OSError):
+            logging.info(f"Downloaded installer to {path}")
+            self.finished.emit(path)
+        except Exception:
+            # Same defensive-broad-except rationale as `_CheckWorker.run`.
             logging.exception("Failed to download installer")
             self.finished.emit(None)
-            return
-        logging.info(f"Downloaded installer to {path}")
-        self.finished.emit(path)
 
 
 class UpdateChecker(BaseWidget):

--- a/tests/test_update_checker_workers.py
+++ b/tests/test_update_checker_workers.py
@@ -1,0 +1,83 @@
+"""Regression coverage for the update-checker workers.
+
+The bug we are guarding against: an unexpected exception type (anything
+outside the narrow ``requests.RequestException`` / ``ValueError`` set the
+workers used to catch) escaped ``run()``, the worker thread died without
+emitting ``finished``, and the caller's ``_busy`` flag stayed True for
+the lifetime of the process — silencing every subsequent menu click.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from src.components.update_checker import _CheckWorker, _DownloadWorker
+
+
+@pytest.fixture
+def check_worker(qtbot):
+    w = _CheckWorker()
+    return w
+
+
+def _wait_finished(qtbot, worker):
+    with qtbot.waitSignal(worker.finished, timeout=2000) as blocker:
+        worker.run()
+    return blocker.args
+
+
+def test_check_worker_emits_finished_on_unexpected_exception(qtbot, check_worker):
+    # An OSError from a frozen-build code path used to escape and wedge
+    # the caller's _busy flag forever — the broad except in run() now
+    # catches it and emits finished(None).
+    with patch('src.components.update_checker.requests.get', side_effect=OSError("ssl boom")):
+        args = _wait_finished(qtbot, check_worker)
+    assert args == [None]
+
+
+def test_check_worker_emits_finished_on_request_exception(qtbot, check_worker):
+    import requests
+    with patch(
+        'src.components.update_checker.requests.get',
+        side_effect=requests.ConnectionError("no network"),
+    ):
+        args = _wait_finished(qtbot, check_worker)
+    assert args == [None]
+
+
+def test_check_worker_emits_finished_when_release_has_no_installer_asset(qtbot, check_worker):
+    class _FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {"tag_name": "9.9.9", "assets": []}
+
+    with patch('src.components.update_checker.requests.get', return_value=_FakeResp()):
+        args = _wait_finished(qtbot, check_worker)
+    assert args == [None]
+
+
+def test_check_worker_emits_release_tuple_on_success(qtbot, check_worker):
+    class _FakeResp:
+        def raise_for_status(self):
+            return None
+
+        def json(self):
+            return {
+                "tag_name": "9.9.9",
+                "assets": [
+                    {"name": "irrelevant.zip"},
+                    {"name": "Installer-9.9.9.exe", "browser_download_url": "https://example/9.9.9.exe"},
+                ],
+            }
+
+    with patch('src.components.update_checker.requests.get', return_value=_FakeResp()):
+        args = _wait_finished(qtbot, check_worker)
+    assert args == [("9.9.9", "https://example/9.9.9.exe")]
+
+
+def test_download_worker_emits_finished_on_unexpected_exception(qtbot, tmp_path):
+    worker = _DownloadWorker("https://example/1.exe", str(tmp_path))
+    with patch('src.components.update_checker.requests.get', side_effect=RuntimeError("???")):
+        args = _wait_finished(qtbot, worker)
+    assert args == [None]


### PR DESCRIPTION
## Summary

Fixes the bug observed in `1.12.0`: clicking **Check for updates...** in the tray did absolutely nothing — no modal, no log entry, the menu just sat there.

### Root cause

`_CheckWorker.run` and `_DownloadWorker.run` caught only a narrow set of exception types (`requests.RequestException` / `ValueError` / `OSError`). Anything outside that set — and frozen-build code paths from inside `requests` / `urllib3` / SSL on the user's installed binary did raise 'anything else' — escaped the worker thread. The `finished` signal was never emitted, so the caller's `_busy` flag stayed `True` for the lifetime of the process. Every subsequent click silently no-op'd because of `if self._busy: return`. Nothing logged because the `logging.exception` call lived inside the same narrow `except` that didn't fire.

### Fix

- Wraps each worker body in a broad `except Exception` that always logs and emits `finished(None)`. The next click then sees `_busy = False` and can run a fresh check; the user gets the standard 'Update check failed' modal in interactive mode.
- Adds five regression tests covering: unexpected exception, `requests.ConnectionError`, success path, missing-installer-asset, and the same unexpected-exception case for the download worker.
- Also pins `requests` into `setup.py`'s explicit cx_Freeze packages list — belt-and-suspenders against auto-detection misses on the next freeze.

## Test plan

- [x] `ruff check .` clean.
- [x] `pytest tests/` — 156 passed (includes the 5 new regression tests).
- [ ] Land, ship a `1.14.0` release, verify on the running tray that **Check for updates...** now responds (either with an 'up-to-date' modal or an 'Update available' modal).