### PR TITLE
fix: watchdog the update check so a stuck worker can recover

### DIFF
--- a/src/components/update_checker.py
+++ b/src/components/update_checker.py
@@ -15,8 +15,10 @@ from ..base.user_settings import UserSettings
 
 LATEST_RELEASE_URL = 'https://api.github.com/repos/dbtdsilva/swiss-windows-knife/releases/latest'
 CHECK_INTERVAL_MS = 1000 * 30 * 60
-NETWORK_TIMEOUT_S = 15
+CONNECT_TIMEOUT_S = 5
+READ_TIMEOUT_S = 15
 DOWNLOAD_TIMEOUT_S = 120
+WATCHDOG_MS = 30_000
 SKIP_VERSION_KEY = 'update_skip_version'
 CHECK_LABEL_IDLE = 'Check for updates...'
 CHECK_LABEL_CHECKING = 'Checking…'
@@ -45,8 +47,12 @@ class _CheckWorker(QObject):
         # / SSL — when one escaped this method, the worker thread died
         # without emitting `finished`, leaving subsequent clicks silently
         # no-oping for the lifetime of the process.
+        logging.info("Update-check worker started; fetching %s", LATEST_RELEASE_URL)
         try:
-            response = requests.get(LATEST_RELEASE_URL, timeout=NETWORK_TIMEOUT_S)
+            response = requests.get(
+                LATEST_RELEASE_URL, timeout=(CONNECT_TIMEOUT_S, READ_TIMEOUT_S),
+            )
+            logging.info("Update-check HTTP status: %s", response.status_code)
             response.raise_for_status()
             data = response.json()
 
@@ -129,7 +135,32 @@ class UpdateChecker(BaseWidget):
         self._set_busy(True)
         if interactive and self._check_action is not None:
             self._check_action.setText(CHECK_LABEL_CHECKING)
+        logging.info("Spawning update-check worker (interactive=%s)", interactive)
         self._spawn_worker(_CheckWorker(), self._on_check_finished)
+        QTimer.singleShot(WATCHDOG_MS, self._check_watchdog)
+
+    def _check_watchdog(self) -> None:
+        # If the worker thread wedged (e.g. requests.get blocked on a
+        # network path that ignores its own timeout), `_busy` would stay
+        # True forever and the menu item would stay greyed out. Force a
+        # recovery so the user can try again instead of having to restart
+        # the app. A late-returning orphan worker is harmless — the
+        # stale-result guard in `_on_check_finished` ignores its result.
+        if not self._busy:
+            return
+        logging.warning(
+            "Update check did not finish within %s ms; forcing recovery.",
+            WATCHDOG_MS,
+        )
+        if self._check_action is not None:
+            self._check_action.setText(CHECK_LABEL_IDLE)
+        self._set_busy(False)
+        if self._interactive:
+            QMessageBox.warning(
+                self, 'Update check timed out',
+                f'No response within {WATCHDOG_MS // 1000} seconds. '
+                'See logs for details.',
+            )
 
     def _spawn_worker(self, worker: QObject, on_finished: Callable[[object], None]) -> None:
         thread = QThread(self)
@@ -143,6 +174,11 @@ class UpdateChecker(BaseWidget):
 
     @Slot(object)
     def _on_check_finished(self, result) -> None:
+        if not self._busy:
+            # The watchdog already fired; this is a late response from a
+            # worker we stopped waiting for. Do not surface it.
+            logging.info("Ignoring stale update-check result (watchdog already fired)")
+            return
         if self._check_action is not None:
             self._check_action.setText(CHECK_LABEL_IDLE)
 

--- a/tests/test_update_checker_workers.py
+++ b/tests/test_update_checker_workers.py
@@ -46,6 +46,8 @@ def test_check_worker_emits_finished_on_request_exception(qtbot, check_worker):
 
 def test_check_worker_emits_finished_when_release_has_no_installer_asset(qtbot, check_worker):
     class _FakeResp:
+        status_code = 200
+
         def raise_for_status(self):
             return None
 
@@ -59,6 +61,8 @@ def test_check_worker_emits_finished_when_release_has_no_installer_asset(qtbot, 
 
 def test_check_worker_emits_release_tuple_on_success(qtbot, check_worker):
     class _FakeResp:
+        status_code = 200
+
         def raise_for_status(self):
             return None
 
@@ -81,3 +85,44 @@ def test_download_worker_emits_finished_on_unexpected_exception(qtbot, tmp_path)
     with patch('src.components.update_checker.requests.get', side_effect=RuntimeError("???")):
         args = _wait_finished(qtbot, worker)
     assert args == [None]
+
+
+def test_watchdog_clears_busy_when_worker_wedges(qtbot, fake_user_settings):
+    """If the worker thread blocks indefinitely (e.g. a network call that
+    ignores its timeout), the watchdog must restore the menu so the user
+    can try again instead of having the action greyed out forever."""
+    from src.components.update_checker import UpdateChecker
+
+    # Stub out the worker spawn so the constructor's queued auto-check
+    # doesn't actually try to hit the network (or leak a thread into
+    # pytest teardown). We're testing the watchdog state machine, not
+    # the worker.
+    with patch.object(UpdateChecker, '_spawn_worker'):
+        checker = UpdateChecker(parent=None)
+        qtbot.addWidget(checker)
+        qtbot.wait(20)
+
+        checker._set_busy(True)
+        checker._interactive = False
+        checker._check_watchdog()
+
+    assert checker._busy is False
+
+
+def test_stale_result_after_watchdog_is_ignored(qtbot, fake_user_settings):
+    """A late-returning worker after the watchdog cleared busy must not
+    pop a misleading 'Update available' modal."""
+    from src.components.update_checker import UpdateChecker
+
+    with patch.object(UpdateChecker, '_spawn_worker'):
+        checker = UpdateChecker(parent=None)
+        qtbot.addWidget(checker)
+        qtbot.wait(20)
+
+        # Simulate watchdog already fired.
+        checker._set_busy(False)
+
+        # Late result from an orphan worker — should be a no-op.
+        checker._on_check_finished(("99.99.99", "https://example/installer.exe"))
+
+    assert checker._busy is False


### PR DESCRIPTION
## Summary

PR #10's broad `except Exception` caught worker-thread crashes — but it can't catch a worker that's *not* crashing, just blocking forever inside `requests.get`. The frozen `1.13.1` build reproducibly wedges in exactly that way: the socket / SSL stack ignores the 15-second read timeout, no exception is ever raised, the broad `except` never fires, `_busy` stays `True`, and the **Check for updates...** menu item stays greyed out for the lifetime of the process.

This change layers three defenses on top:

- **30-second watchdog** kicked off from `check_updates` via `QTimer.singleShot`. If `_busy` is still `True` after `WATCHDOG_MS`, force-clear it (and pop a "timed out" modal in interactive mode). The menu becomes responsive again instead of needing an app restart.
- **Diagnostic logs** at the worker's entry (`Update-check worker started; fetching <url>`) and after the HTTP call (`Update-check HTTP status: <code>`). Next time something stalls in production, the logs will show exactly where.
- **Split `(connect, read)` timeout** of `(5, 15)` instead of a single `timeout=15`, giving a faster failure path when DNS or TCP handshake hangs.

A late-returning worker after the watchdog has fired is treated as stale by `_on_check_finished` (logs `Ignoring stale update-check result` and returns), so the user never sees a confusing duplicate modal.

## Test plan

- [x] `ruff check .` clean.
- [x] `pytest tests/` — 158 passed (5 prior worker tests + 2 new watchdog tests).
- [ ] After merge → release → install on the wedged tray, confirm: app boots, "Check for updates..." either responds with the standard modal within ~15 s, or pops "Update check timed out" within 30 s. Either way, the menu becomes responsive again.