### PR TITLE
fix: subclass QThread directly so the worker run() actually runs

### DIFF
--- a/src/components/update_checker.py
+++ b/src/components/update_checker.py
@@ -2,10 +2,9 @@ import logging
 import os
 import subprocess
 import tempfile
-from collections.abc import Callable
 
 import requests
-from PySide6.QtCore import QCoreApplication, QObject, QThread, QTimer, Signal, Slot
+from PySide6.QtCore import QCoreApplication, QThread, QTimer, Signal, Slot
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QCheckBox, QMenu, QMessageBox, QWidget
 
@@ -35,18 +34,21 @@ def _parse_version(text: str) -> tuple[int, ...]:
     return tuple(out)
 
 
-class _CheckWorker(QObject):
-    finished = Signal(object)
+class _CheckThread(QThread):
+    """Fetches the latest release metadata from GitHub on its own thread.
 
-    @Slot()
+    Subclasses `QThread` directly (rather than the worker-as-QObject +
+    `moveToThread` + `started.connect(run)` pattern) because, in the frozen
+    cx_Freeze build, the latter pattern was reproducibly failing to invoke
+    the worker's `run()` slot — the thread started, but the started→run
+    signal-slot connection never fired. Putting the work in `QThread.run`
+    bypasses that connection entirely; the thread's main function IS the
+    worker code.
+    """
+
+    result_ready = Signal(object)
+
     def run(self) -> None:
-        # `finished` MUST be emitted on every exit path so that the caller's
-        # `_busy` flag is cleared. We catch a broad Exception (rather than only
-        # `requests.RequestException` / `ValueError`) because frozen builds
-        # have surfaced unexpected error types from inside requests / urllib3
-        # / SSL — when one escaped this method, the worker thread died
-        # without emitting `finished`, leaving subsequent clicks silently
-        # no-oping for the lifetime of the process.
         logging.info("Update-check worker started; fetching %s", LATEST_RELEASE_URL)
         try:
             response = requests.get(
@@ -65,26 +67,29 @@ class _CheckWorker(QObject):
 
             if installer_url is None or 'tag_name' not in data:
                 logging.warning("No installer asset in latest release")
-                self.finished.emit(None)
+                self.result_ready.emit(None)
                 return
 
-            self.finished.emit((data['tag_name'], installer_url))
+            self.result_ready.emit((data['tag_name'], installer_url))
         except Exception:
             logging.exception("Failed to query for updates")
-            self.finished.emit(None)
+            self.result_ready.emit(None)
 
 
-class _DownloadWorker(QObject):
-    finished = Signal(object)
+class _DownloadThread(QThread):
+    """Streams the installer to disk on its own thread. Same QThread-subclass
+    rationale as `_CheckThread`."""
 
-    def __init__(self, url: str, dest_dir: str, parent: QObject | None = None) -> None:
+    result_ready = Signal(object)
+
+    def __init__(self, url: str, dest_dir: str, parent=None) -> None:
         super().__init__(parent)
         self._url = url
         self._dest_dir = dest_dir
 
-    @Slot()
     def run(self) -> None:
         path = os.path.join(self._dest_dir, os.path.basename(self._url))
+        logging.info("Update-download worker started; fetching %s", self._url)
         try:
             with requests.get(self._url, stream=True, timeout=DOWNLOAD_TIMEOUT_S) as r:
                 r.raise_for_status()
@@ -92,11 +97,10 @@ class _DownloadWorker(QObject):
                     for chunk in r.iter_content(chunk_size=8192):
                         f.write(chunk)
             logging.info(f"Downloaded installer to {path}")
-            self.finished.emit(path)
+            self.result_ready.emit(path)
         except Exception:
-            # Same defensive-broad-except rationale as `_CheckWorker.run`.
             logging.exception("Failed to download installer")
-            self.finished.emit(None)
+            self.result_ready.emit(None)
 
 
 class UpdateChecker(BaseWidget):
@@ -110,6 +114,7 @@ class UpdateChecker(BaseWidget):
         self._busy = False
         self._interactive = False
         self._check_action: QAction | None = None
+        self._active_thread: QThread | None = None
 
         self.timer = QTimer(self)
         self.timer.timeout.connect(self.check_updates)
@@ -136,7 +141,11 @@ class UpdateChecker(BaseWidget):
         if interactive and self._check_action is not None:
             self._check_action.setText(CHECK_LABEL_CHECKING)
         logging.info("Spawning update-check worker (interactive=%s)", interactive)
-        self._spawn_worker(_CheckWorker(), self._on_check_finished)
+        thread = _CheckThread(self)
+        thread.result_ready.connect(self._on_check_finished)
+        thread.finished.connect(thread.deleteLater)
+        self._active_thread = thread
+        thread.start()
         QTimer.singleShot(WATCHDOG_MS, self._check_watchdog)
 
     def _check_watchdog(self) -> None:
@@ -161,16 +170,6 @@ class UpdateChecker(BaseWidget):
                 f'No response within {WATCHDOG_MS // 1000} seconds. '
                 'See logs for details.',
             )
-
-    def _spawn_worker(self, worker: QObject, on_finished: Callable[[object], None]) -> None:
-        thread = QThread(self)
-        worker.moveToThread(thread)
-        thread.started.connect(worker.run)  # type: ignore[attr-defined]
-        worker.finished.connect(on_finished)  # type: ignore[attr-defined]
-        worker.finished.connect(thread.quit)  # type: ignore[attr-defined]
-        thread.finished.connect(worker.deleteLater)
-        thread.finished.connect(thread.deleteLater)
-        thread.start()
 
     @Slot(object)
     def _on_check_finished(self, result) -> None:
@@ -205,7 +204,11 @@ class UpdateChecker(BaseWidget):
             return
 
         dest_dir = tempfile.mkdtemp(prefix='swk-update-')
-        self._spawn_worker(_DownloadWorker(installer_url, dest_dir), self._on_download_finished)
+        thread = _DownloadThread(installer_url, dest_dir, self)
+        thread.result_ready.connect(self._on_download_finished)
+        thread.finished.connect(thread.deleteLater)
+        self._active_thread = thread
+        thread.start()
 
     @Slot(object)
     def _on_download_finished(self, path) -> None:

--- a/tests/test_update_checker_workers.py
+++ b/tests/test_update_checker_workers.py
@@ -1,50 +1,40 @@
-"""Regression coverage for the update-checker workers.
-
-The bug we are guarding against: an unexpected exception type (anything
-outside the narrow ``requests.RequestException`` / ``ValueError`` set the
-workers used to catch) escaped ``run()``, the worker thread died without
-emitting ``finished``, and the caller's ``_busy`` flag stayed True for
-the lifetime of the process — silencing every subsequent menu click.
-"""
+"""Regression coverage for the update-checker worker threads."""
 from unittest.mock import patch
 
 import pytest
 
-from src.components.update_checker import _CheckWorker, _DownloadWorker
+from src.components.update_checker import _CheckThread, _DownloadThread
 
 
-@pytest.fixture
-def check_worker(qtbot):
-    w = _CheckWorker()
-    return w
-
-
-def _wait_finished(qtbot, worker):
-    with qtbot.waitSignal(worker.finished, timeout=2000) as blocker:
-        worker.run()
+def _wait_result(qtbot, thread):
+    with qtbot.waitSignal(thread.result_ready, timeout=2000) as blocker:
+        thread.run()  # call run() directly on the test thread; we want the
+        # exception/branch behavior, not the Qt threading mechanics.
     return blocker.args
 
 
-def test_check_worker_emits_finished_on_unexpected_exception(qtbot, check_worker):
-    # An OSError from a frozen-build code path used to escape and wedge
-    # the caller's _busy flag forever — the broad except in run() now
-    # catches it and emits finished(None).
+@pytest.fixture
+def check_thread(qtbot):
+    return _CheckThread()
+
+
+def test_check_thread_emits_none_on_unexpected_exception(qtbot, check_thread):
     with patch('src.components.update_checker.requests.get', side_effect=OSError("ssl boom")):
-        args = _wait_finished(qtbot, check_worker)
+        args = _wait_result(qtbot, check_thread)
     assert args == [None]
 
 
-def test_check_worker_emits_finished_on_request_exception(qtbot, check_worker):
+def test_check_thread_emits_none_on_request_exception(qtbot, check_thread):
     import requests
     with patch(
         'src.components.update_checker.requests.get',
         side_effect=requests.ConnectionError("no network"),
     ):
-        args = _wait_finished(qtbot, check_worker)
+        args = _wait_result(qtbot, check_thread)
     assert args == [None]
 
 
-def test_check_worker_emits_finished_when_release_has_no_installer_asset(qtbot, check_worker):
+def test_check_thread_emits_none_when_release_has_no_installer_asset(qtbot, check_thread):
     class _FakeResp:
         status_code = 200
 
@@ -55,11 +45,11 @@ def test_check_worker_emits_finished_when_release_has_no_installer_asset(qtbot, 
             return {"tag_name": "9.9.9", "assets": []}
 
     with patch('src.components.update_checker.requests.get', return_value=_FakeResp()):
-        args = _wait_finished(qtbot, check_worker)
+        args = _wait_result(qtbot, check_thread)
     assert args == [None]
 
 
-def test_check_worker_emits_release_tuple_on_success(qtbot, check_worker):
+def test_check_thread_emits_release_tuple_on_success(qtbot, check_thread):
     class _FakeResp:
         status_code = 200
 
@@ -76,36 +66,31 @@ def test_check_worker_emits_release_tuple_on_success(qtbot, check_worker):
             }
 
     with patch('src.components.update_checker.requests.get', return_value=_FakeResp()):
-        args = _wait_finished(qtbot, check_worker)
+        args = _wait_result(qtbot, check_thread)
     assert args == [("9.9.9", "https://example/9.9.9.exe")]
 
 
-def test_download_worker_emits_finished_on_unexpected_exception(qtbot, tmp_path):
-    worker = _DownloadWorker("https://example/1.exe", str(tmp_path))
+def test_download_thread_emits_none_on_unexpected_exception(qtbot, tmp_path):
+    thread = _DownloadThread("https://example/1.exe", str(tmp_path))
     with patch('src.components.update_checker.requests.get', side_effect=RuntimeError("???")):
-        args = _wait_finished(qtbot, worker)
+        args = _wait_result(qtbot, thread)
     assert args == [None]
 
 
 def test_watchdog_clears_busy_when_worker_wedges(qtbot, fake_user_settings):
-    """If the worker thread blocks indefinitely (e.g. a network call that
-    ignores its timeout), the watchdog must restore the menu so the user
-    can try again instead of having the action greyed out forever."""
+    """If the worker thread blocks indefinitely, the watchdog must restore
+    the menu so the user can try again instead of having the action greyed
+    out forever."""
     from src.components.update_checker import UpdateChecker
 
-    # Stub out the worker spawn so the constructor's queued auto-check
-    # doesn't actually try to hit the network (or leak a thread into
-    # pytest teardown). We're testing the watchdog state machine, not
-    # the worker.
-    with patch.object(UpdateChecker, '_spawn_worker'):
+    with patch.object(UpdateChecker, 'check_updates'):
         checker = UpdateChecker(parent=None)
         qtbot.addWidget(checker)
         qtbot.wait(20)
 
-        checker._set_busy(True)
-        checker._interactive = False
-        checker._check_watchdog()
-
+    checker._set_busy(True)
+    checker._interactive = False
+    checker._check_watchdog()
     assert checker._busy is False
 
 
@@ -114,15 +99,11 @@ def test_stale_result_after_watchdog_is_ignored(qtbot, fake_user_settings):
     pop a misleading 'Update available' modal."""
     from src.components.update_checker import UpdateChecker
 
-    with patch.object(UpdateChecker, '_spawn_worker'):
+    with patch.object(UpdateChecker, 'check_updates'):
         checker = UpdateChecker(parent=None)
         qtbot.addWidget(checker)
         qtbot.wait(20)
 
-        # Simulate watchdog already fired.
-        checker._set_busy(False)
-
-        # Late result from an orphan worker — should be a no-op.
-        checker._on_check_finished(("99.99.99", "https://example/installer.exe"))
-
+    checker._set_busy(False)
+    checker._on_check_finished(("99.99.99", "https://example/installer.exe"))
     assert checker._busy is False


### PR DESCRIPTION
## Summary

The `1.13.2` diagnostic logs identified the root cause:

```
23:12:06,525 INFO ... Spawning update-check worker (interactive=False)
                      <-- expected: 'Update-check worker started; fetching ...'
23:12:36,529 WARN ... Update check did not finish within 30000 ms; forcing recovery.
```

The thread starts, but the `started → worker.run` signal-slot connection never invokes `run()` in the cx_Freeze build (likely a slot-registration / Qt-meta issue specific to the frozen runtime). The watchdog correctly recovers the UI 30 s later, but no actual check ever happens.

This change replaces the worker-as-QObject + `moveToThread` + `started.connect(run)` pattern with a direct `QThread` subclass: `_CheckThread.run()` and `_DownloadThread.run()` *are* the threads' main functions, invoked by Qt's own virtual dispatch, bypassing whatever broke the signal-slot connection in the frozen build. The result still flows back through a `result_ready(object)` signal so the existing watchdog / stale-result / `_on_check_finished` logic is unchanged.

## Test plan

- [x] `ruff check .` clean.
- [x] `pytest tests/` — 158 passed (7 worker / watchdog tests).
- [ ] After merge → release → install on a wedged tray, confirm: log shows `Update-check worker started; fetching <url>` immediately after `Spawning update-check worker`, and either the standard up-to-date / update-available modal lands, or `Failed to query for updates` is logged with a real exception traceback.