### PR TITLE
feat: move display automation from tray menu to Configuration

### DIFF
--- a/docs/superpowers/plans/2026-04-30-display-automation-config-panel.md
+++ b/docs/superpowers/plans/2026-04-30-display-automation-config-panel.md
@@ -1,0 +1,752 @@
+# Display Automation Config Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the per-monitor "Display automation" submenu (per-monitor on-connect/on-disconnect input choices and USB-watcher selection) out of the tray menu and into a new `DisplayAutomationConfigPanel` shown in the unified Configuration dialog. This eliminates synchronous DDC/CI capability reads and WMI PnP enumeration from the startup path — they happen only when the user opens Configuration and the panel populates itself asynchronously.
+
+**Architecture:** A new `DisplayAutomationConfigPanel(ConfigPanel)` lives next to the device_display_mapper plugin. `DeviceDisplayMapperPlugin.retrieve_menus()` returns `[]`; `retrieve_config_panels()` returns `[DisplayAutomationConfigPanel(self)]`. The panel takes injectable `list_monitors` / `list_usb_devices` callables (defaulted to real impls); tests pass fakes so they don't need hardware. The panel renders a "Loading…" placeholder, dispatches monitor discovery on the existing `runner()` (DDC/CI thread) and USB discovery on a `QThread` worker, then rebuilds its widgets when results arrive over Qt signals. `apply()` writes the same settings keys the menu writes today (`display_usb_watcher`, `display_on_connect_<id>`, `display_on_disconnect_<id>`) so existing user settings carry over with no migration. The runtime hot-path (`device_changed` → `_apply_input_source`) is untouched.
+
+**Tech Stack:** PySide6 (`QGroupBox`, `QComboBox`, `QFormLayout`, `QThread`, `Signal`/`Slot`), existing `runner()` from `src/base/monitor_runner.py`, `monitorcontrol`, `wmi`, pytest + pytest-qt.
+
+---
+
+### Task 1: Discovery helpers (extracted, injectable)
+
+Pulls the synchronous discovery code out of the plugin so the panel can call it from a worker, and tests can replace it. No behavior change yet.
+
+**Files:**
+- Create: `src/plugins/device_display_mapper/discovery.py`
+- Test: none (these helpers wrap third-party calls — covered by the panel test via fakes in Task 4)
+
+- [ ] **Step 1: Create `discovery.py` with two pure helper functions**
+
+```python
+import logging
+
+import monitorcontrol
+
+from .device_listener import DeviceListener
+from .monitor_info import MonitorInfo, MonitorInfoCtx
+
+
+def list_monitors(monitor_info_ctx: MonitorInfoCtx) -> list[MonitorInfo]:
+    """Read DDC/CI capabilities for every attached monitor.
+
+    MUST run on the dedicated monitor-runner thread (see
+    `src/base/monitor_runner.py`); calling from the GUI thread will block
+    for seconds per monitor.
+    """
+    out: list[MonitorInfo] = []
+    for monitor in monitorcontrol.get_monitors():
+        with monitor:
+            info = monitor_info_ctx.get_monitor_info_by_monitor(monitor=monitor)
+            if info is None:
+                logging.warning("No monitor info available for one of the attached displays")
+                continue
+            out.append(info)
+    return out
+
+
+def list_usb_devices(device_listener: DeviceListener):
+    """Enumerate currently-attached real USB devices via WMI.
+
+    MUST run off the GUI thread; `Win32_PnPEntity` enumeration is multi-second.
+    """
+    return device_listener.get_real_usb_devices()
+```
+
+- [ ] **Step 2: Run the test suite to confirm nothing regressed**
+
+Run: `./env/Scripts/python.exe -m pytest tests/ -q`
+Expected: all existing tests still pass (no new tests yet).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/plugins/device_display_mapper/discovery.py
+git commit -m "refactor: extract display-automation discovery helpers"
+```
+
+---
+
+### Task 2: `DisplayAutomationConfigPanel` — failing test for empty state
+
+A panel constructed with empty fakes shows the placeholder, has no monitor groups, and `apply()` is a no-op.
+
+**Files:**
+- Test: `tests/test_display_automation_panel.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_display_automation_panel.py`:
+
+```python
+import pytest
+
+
+class _FakeMonitorInfo:
+    def __init__(self, device_id, device_name, model, inputs):
+        self.device_id = device_id
+        self.device_name = device_name
+        self.model = model
+        self.inputs = inputs
+
+
+class _FakeDevice:
+    def __init__(self, id, name, description="", manufacturer=""):
+        self.id = id
+        self.name = name
+        self.description = description
+        self.manufacturer = manufacturer
+
+
+@pytest.fixture
+def make_panel(qtbot, fake_user_settings, silent_messagebox):
+    """Build a panel with controllable, sync providers."""
+    from src.plugins.device_display_mapper.display_automation_panel import (
+        DisplayAutomationConfigPanel,
+    )
+
+    def _make(monitors=None, usb_devices=None):
+        panel = DisplayAutomationConfigPanel(
+            parent=None,
+            list_monitors=lambda: list(monitors or []),
+            list_usb_devices=lambda: list(usb_devices or []),
+            schedule_discovery=lambda fn: fn(),  # run inline for tests
+        )
+        qtbot.addWidget(panel)
+        return panel
+
+    return _make
+
+
+def test_panel_with_no_monitors_or_devices_apply_is_noop(make_panel, fake_user_settings):
+    panel = make_panel(monitors=[], usb_devices=[])
+    assert panel.apply() is True
+    # No settings should be written when there is nothing to choose from.
+    assert fake_user_settings.get('display_usb_watcher') is None
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_display_automation_panel.py -q`
+Expected: FAIL with `ModuleNotFoundError: src.plugins.device_display_mapper.display_automation_panel`.
+
+---
+
+### Task 3: `DisplayAutomationConfigPanel` — minimal skeleton
+
+Build a panel that renders nothing (just the placeholder), with the constructor signature the tests expect. No discovery yet — that comes when we add the monitor/USB tests.
+
+**Files:**
+- Create: `src/plugins/device_display_mapper/display_automation_panel.py`
+
+- [ ] **Step 1: Implement the panel skeleton**
+
+```python
+from collections.abc import Callable
+from typing import Any
+
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+from ...base.config_panel import ConfigPanel
+from ...base.user_settings import UserSettings
+
+
+class DisplayAutomationConfigPanel(ConfigPanel):
+
+    title = "Display automation"
+
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        *,
+        list_monitors: Callable[[], list[Any]] | None = None,
+        list_usb_devices: Callable[[], list[Any]] | None = None,
+        schedule_discovery: Callable[[Callable[[], None]], None] | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._user_settings = UserSettings.instance()
+        self._list_monitors = list_monitors
+        self._list_usb_devices = list_usb_devices
+        self._schedule = schedule_discovery or (lambda fn: fn())
+
+        self._monitors: list[Any] = []
+        self._usb_devices: list[Any] = []
+
+        self._layout = QVBoxLayout(self)
+        self._placeholder = QLabel("Reading monitor capabilities…", self)
+        self._layout.addWidget(self._placeholder)
+
+        self._monitor_groups: dict[str, dict] = {}  # device_id -> {connect_combo, disconnect_combo}
+        self._usb_combo = None
+
+        if list_monitors is not None or list_usb_devices is not None:
+            self._schedule(self._populate)
+
+    def _populate(self) -> None:
+        self._monitors = list(self._list_monitors()) if self._list_monitors else []
+        self._usb_devices = list(self._list_usb_devices()) if self._list_usb_devices else []
+        # Widgets are added in Task 5; for now the placeholder stays.
+
+    def apply(self) -> bool:
+        return True
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_display_automation_panel.py -q`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/plugins/device_display_mapper/display_automation_panel.py tests/test_display_automation_panel.py
+git commit -m "feat: scaffold display-automation config panel"
+```
+
+---
+
+### Task 4: Render USB watcher combobox + persist on apply (failing test → impl → pass)
+
+**Files:**
+- Modify: `src/plugins/device_display_mapper/display_automation_panel.py`
+- Modify: `tests/test_display_automation_panel.py`
+
+- [ ] **Step 1: Add failing tests for USB rendering and persistence**
+
+Append to `tests/test_display_automation_panel.py`:
+
+```python
+def test_panel_renders_usb_devices_and_persists_selection(make_panel, fake_user_settings):
+    devices = [
+        _FakeDevice(id="USB\\VID_1234&PID_5678\\AAA", name="Dock A", description="USB-C dock"),
+        _FakeDevice(id="USB\\VID_9999&PID_1111\\BBB", name="Mouse", description="Optical mouse"),
+    ]
+    panel = make_panel(monitors=[], usb_devices=devices)
+
+    assert panel._usb_combo is not None
+    # First entry is the "(none)" option, then one entry per device, in input order.
+    assert panel._usb_combo.count() == 1 + len(devices)
+
+    panel._usb_combo.setCurrentIndex(2)  # Select "Mouse"
+    assert panel.apply() is True
+    assert fake_user_settings.get('display_usb_watcher') == "USB\\VID_9999&PID_1111\\BBB"
+
+
+def test_panel_preselects_existing_usb_watcher(make_panel, fake_user_settings):
+    fake_user_settings.set('display_usb_watcher', "USB\\VID_1234&PID_5678\\AAA")
+    devices = [
+        _FakeDevice(id="USB\\VID_1234&PID_5678\\AAA", name="Dock A"),
+        _FakeDevice(id="USB\\VID_9999&PID_1111\\BBB", name="Mouse"),
+    ]
+    panel = make_panel(monitors=[], usb_devices=devices)
+
+    # Index 1 is the first device in our list; 0 is the "(none)" sentinel.
+    assert panel._usb_combo.currentIndex() == 1
+
+
+def test_panel_apply_with_none_clears_usb_watcher(make_panel, fake_user_settings):
+    fake_user_settings.set('display_usb_watcher', "USB\\VID_1234&PID_5678\\AAA")
+    devices = [_FakeDevice(id="USB\\VID_1234&PID_5678\\AAA", name="Dock A")]
+    panel = make_panel(monitors=[], usb_devices=devices)
+    panel._usb_combo.setCurrentIndex(0)  # "(none)"
+
+    assert panel.apply() is True
+    assert fake_user_settings.get('display_usb_watcher') is None
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_display_automation_panel.py -q`
+Expected: FAIL — `_usb_combo` is `None`, count check fails.
+
+- [ ] **Step 3: Implement USB rendering and persistence**
+
+Replace the `_populate` method and `apply` in `display_automation_panel.py`, and add helpers:
+
+```python
+from PySide6.QtWidgets import QComboBox, QFormLayout, QGroupBox, QLabel, QVBoxLayout, QWidget
+
+USB_WATCHER_KEY = 'display_usb_watcher'
+
+
+class DisplayAutomationConfigPanel(ConfigPanel):
+    # ... (constructor unchanged from Task 3, but call _populate unconditionally now)
+
+    def __init__(self, parent=None, *, list_monitors=None, list_usb_devices=None, schedule_discovery=None):
+        super().__init__(parent)
+        self._user_settings = UserSettings.instance()
+        self._list_monitors = list_monitors
+        self._list_usb_devices = list_usb_devices
+        self._schedule = schedule_discovery or (lambda fn: fn())
+
+        self._monitors = []
+        self._usb_devices = []
+
+        self._layout = QVBoxLayout(self)
+        self._placeholder = QLabel("Reading monitor capabilities…", self)
+        self._layout.addWidget(self._placeholder)
+
+        self._monitor_groups: dict[str, dict] = {}
+        self._usb_combo: QComboBox | None = None
+
+        self._schedule(self._populate)
+
+    def _populate(self) -> None:
+        self._monitors = list(self._list_monitors()) if self._list_monitors else []
+        self._usb_devices = list(self._list_usb_devices()) if self._list_usb_devices else []
+
+        self._placeholder.hide()
+        self._build_usb_section()
+
+    def _build_usb_section(self) -> None:
+        box = QGroupBox("USB trigger for display switch", self)
+        form = QFormLayout(box)
+
+        combo = QComboBox(box)
+        combo.addItem("(none)", userData=None)
+        for device in self._usb_devices:
+            label = f"{device.name} ({device.id})"
+            combo.addItem(label, userData=device.id)
+
+        current = self._user_settings.get(USB_WATCHER_KEY)
+        if current is not None:
+            for i in range(combo.count()):
+                if combo.itemData(i) == current:
+                    combo.setCurrentIndex(i)
+                    break
+
+        form.addRow("Watch:", combo)
+        self._usb_combo = combo
+        self._layout.addWidget(box)
+
+    def apply(self) -> bool:
+        if self._usb_combo is not None:
+            data = self._usb_combo.currentData()
+            self._user_settings.set(USB_WATCHER_KEY, data)
+        return True
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_display_automation_panel.py -q`
+Expected: PASS (all tests in this file).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plugins/device_display_mapper/display_automation_panel.py tests/test_display_automation_panel.py
+git commit -m "feat: render USB-watcher combobox in display-automation panel"
+```
+
+---
+
+### Task 5: Render per-monitor input pickers + persist on apply (failing test → impl → pass)
+
+**Files:**
+- Modify: `src/plugins/device_display_mapper/display_automation_panel.py`
+- Modify: `tests/test_display_automation_panel.py`
+
+- [ ] **Step 1: Add failing tests**
+
+Append to `tests/test_display_automation_panel.py`:
+
+```python
+def test_panel_renders_per_monitor_input_choices_and_persists(make_panel, fake_user_settings):
+    monitors = [
+        _FakeMonitorInfo(
+            device_id="MON-A-DEVID",
+            device_name="\\\\.\\DISPLAY1",
+            model="Dell U2723QE",
+            inputs=["DP1", "HDMI1", "USBC"],
+        ),
+        _FakeMonitorInfo(
+            device_id="MON-B-DEVID",
+            device_name="\\\\.\\DISPLAY2",
+            model="LG 27UP850",
+            inputs=["DP1", "HDMI2"],
+        ),
+    ]
+    panel = make_panel(monitors=monitors, usb_devices=[])
+
+    assert "MON-A-DEVID" in panel._monitor_groups
+    assert "MON-B-DEVID" in panel._monitor_groups
+
+    a = panel._monitor_groups["MON-A-DEVID"]
+    # Each combobox has the inputs plus a "(unchanged)" sentinel at index 0.
+    assert a["connect_combo"].count() == 1 + 3
+    assert a["disconnect_combo"].count() == 1 + 3
+
+    a["connect_combo"].setCurrentIndex(2)     # "HDMI1" on connect
+    a["disconnect_combo"].setCurrentIndex(1)  # "DP1" on disconnect
+
+    assert panel.apply() is True
+    assert fake_user_settings.get('display_on_connect_MON-A-DEVID') == "HDMI1"
+    assert fake_user_settings.get('display_on_disconnect_MON-A-DEVID') == "DP1"
+    # Untouched monitor keeps its "(unchanged)" sentinel — no key written.
+    assert fake_user_settings.get('display_on_connect_MON-B-DEVID') is None
+
+
+def test_panel_preselects_existing_per_monitor_choice(make_panel, fake_user_settings):
+    fake_user_settings.set('display_on_connect_MON-A-DEVID', "HDMI1")
+    fake_user_settings.set('display_on_disconnect_MON-A-DEVID', "DP1")
+    monitors = [
+        _FakeMonitorInfo(
+            device_id="MON-A-DEVID",
+            device_name="\\\\.\\DISPLAY1",
+            model="Dell U2723QE",
+            inputs=["DP1", "HDMI1", "USBC"],
+        ),
+    ]
+    panel = make_panel(monitors=monitors, usb_devices=[])
+
+    a = panel._monitor_groups["MON-A-DEVID"]
+    # "HDMI1" is index 2 (after the "(unchanged)" sentinel + "DP1" at index 1).
+    assert a["connect_combo"].currentText() == "HDMI1"
+    assert a["disconnect_combo"].currentText() == "DP1"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_display_automation_panel.py -q`
+Expected: FAIL — no monitor groups built yet.
+
+- [ ] **Step 3: Implement per-monitor rendering and persistence**
+
+Add to `display_automation_panel.py`:
+
+```python
+ON_CONNECT_KEY_PREFIX = 'display_on_connect_'
+ON_DISCONNECT_KEY_PREFIX = 'display_on_disconnect_'
+
+UNCHANGED_LABEL = "(unchanged)"
+```
+
+Add a `_build_monitor_section` method and call it from `_populate` after `_build_usb_section()`:
+
+```python
+    def _populate(self) -> None:
+        self._monitors = list(self._list_monitors()) if self._list_monitors else []
+        self._usb_devices = list(self._list_usb_devices()) if self._list_usb_devices else []
+
+        self._placeholder.hide()
+        self._build_usb_section()
+        for info in self._monitors:
+            self._build_monitor_section(info)
+
+    def _build_monitor_section(self, info) -> None:
+        box = QGroupBox(f"{info.model} ({info.device_name})", self)
+        form = QFormLayout(box)
+
+        connect_combo = self._make_input_combo(info.inputs, info.device_id, ON_CONNECT_KEY_PREFIX, box)
+        disconnect_combo = self._make_input_combo(info.inputs, info.device_id, ON_DISCONNECT_KEY_PREFIX, box)
+
+        form.addRow("On USB connect:", connect_combo)
+        form.addRow("On USB disconnect:", disconnect_combo)
+
+        self._monitor_groups[info.device_id] = {
+            "connect_combo": connect_combo,
+            "disconnect_combo": disconnect_combo,
+        }
+        self._layout.addWidget(box)
+
+    def _make_input_combo(self, inputs, device_id, key_prefix, parent) -> QComboBox:
+        combo = QComboBox(parent)
+        combo.addItem(UNCHANGED_LABEL, userData=None)
+        for entry in inputs:
+            combo.addItem(str(entry), userData=entry)
+
+        current = self._user_settings.get(key_prefix + device_id)
+        if current is not None:
+            for i in range(combo.count()):
+                if str(combo.itemData(i)) == str(current):
+                    combo.setCurrentIndex(i)
+                    break
+        return combo
+```
+
+Update `apply()` to also persist per-monitor choices:
+
+```python
+    def apply(self) -> bool:
+        if self._usb_combo is not None:
+            self._user_settings.set(USB_WATCHER_KEY, self._usb_combo.currentData())
+        for device_id, widgets in self._monitor_groups.items():
+            for key_prefix, combo_key in (
+                (ON_CONNECT_KEY_PREFIX, "connect_combo"),
+                (ON_DISCONNECT_KEY_PREFIX, "disconnect_combo"),
+            ):
+                data = widgets[combo_key].currentData()
+                if data is None:
+                    # "(unchanged)" — leave existing setting alone.
+                    continue
+                self._user_settings.set(key_prefix + device_id, data)
+        return True
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_display_automation_panel.py -q`
+Expected: PASS (all panel tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plugins/device_display_mapper/display_automation_panel.py tests/test_display_automation_panel.py
+git commit -m "feat: render per-monitor input choices in display-automation panel"
+```
+
+---
+
+### Task 6: Async discovery wiring (real `runner()` + WMI worker `QThread`)
+
+The default `schedule_discovery` callable should put discovery off the GUI thread. Monitor reads go via `runner()`; the WMI USB enumeration goes onto a one-shot `QThread`.
+
+**Files:**
+- Modify: `src/plugins/device_display_mapper/display_automation_panel.py`
+- Modify: `tests/test_display_automation_panel.py`
+
+- [ ] **Step 1: Add a failing test that the panel works with async-style schedulers**
+
+Append to `tests/test_display_automation_panel.py`:
+
+```python
+def test_panel_populates_when_discovery_completes_async(make_panel, fake_user_settings):
+    """When schedule_discovery defers `_populate`, the panel still shows the
+    placeholder before discovery and the widgets after."""
+    deferred: list = []
+
+    def make_panel_async(**kwargs):
+        from src.plugins.device_display_mapper.display_automation_panel import (
+            DisplayAutomationConfigPanel,
+        )
+        panel = DisplayAutomationConfigPanel(
+            parent=None,
+            list_monitors=lambda: [],
+            list_usb_devices=lambda: [_FakeDevice(id="X", name="X")],
+            schedule_discovery=lambda fn: deferred.append(fn),
+        )
+        return panel
+
+    panel = make_panel_async()
+    assert panel._placeholder.isHidden() is False  # placeholder visible
+    assert panel._usb_combo is None  # not yet populated
+
+    # Simulate async completion.
+    for fn in deferred:
+        fn()
+
+    assert panel._placeholder.isHidden() is True
+    assert panel._usb_combo is not None
+```
+
+- [ ] **Step 2: Run to verify it passes against the existing implementation**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_display_automation_panel.py -q`
+Expected: PASS — the existing implementation already supports custom schedulers.
+
+(If it fails, the most likely cause is that `_placeholder.isHidden()` is True before show — adjust by asserting `_placeholder.text() == "Reading monitor capabilities…"` instead of visibility.)
+
+- [ ] **Step 3: Implement the real default schedulers**
+
+Add at the bottom of `display_automation_panel.py`:
+
+```python
+from PySide6.QtCore import QObject, QThread, Qt, Signal
+
+from ...base.monitor_runner import runner
+from .device_listener import DeviceListener
+from .discovery import list_monitors as _list_monitors_default
+from .discovery import list_usb_devices as _list_usb_devices_default
+from .monitor_info import MonitorInfoCtx
+
+
+class _UsbWorker(QObject):
+    finished = Signal(list)
+
+    def __init__(self, device_listener: DeviceListener) -> None:
+        super().__init__()
+        self._device_listener = device_listener
+
+    def run(self) -> None:
+        try:
+            devices = list(_list_usb_devices_default(self._device_listener))
+        except Exception:
+            import logging
+            logging.exception("USB discovery failed")
+            devices = []
+        self.finished.emit(devices)
+
+
+def _default_schedule(panel: "DisplayAutomationConfigPanel", plugin) -> None:
+    """Real-world scheduler: monitor discovery on `runner()`, USB on a QThread.
+
+    Both results land back on the GUI thread via queued Qt signals so the
+    panel can rebuild widgets safely.
+    """
+    monitor_results: dict = {"value": None}
+    usb_results: dict = {"value": None}
+
+    def _maybe_finalize() -> None:
+        if monitor_results["value"] is None or usb_results["value"] is None:
+            return
+        panel._monitors = monitor_results["value"]
+        panel._usb_devices = usb_results["value"]
+        panel._placeholder.hide()
+        panel._build_usb_section()
+        for info in panel._monitors:
+            panel._build_monitor_section(info)
+
+    def _on_monitors_done(monitors):
+        monitor_results["value"] = monitors
+        _maybe_finalize()
+
+    def _on_usb_done(devices):
+        usb_results["value"] = devices
+        _maybe_finalize()
+
+    # Bridge the runner-thread callback back to the GUI thread.
+    class _Bridge(QObject):
+        monitors_ready = Signal(list)
+
+    bridge = _Bridge(panel)
+    bridge.monitors_ready.connect(_on_monitors_done, Qt.ConnectionType.QueuedConnection)
+
+    def _read_monitors():
+        try:
+            monitors = _list_monitors_default(plugin.monitor_info_ctx)
+        except Exception:
+            import logging
+            logging.exception("Monitor discovery failed")
+            monitors = []
+        bridge.monitors_ready.emit(monitors)
+
+    runner().submit(_read_monitors)
+
+    thread = QThread(panel)
+    worker = _UsbWorker(plugin.device_listener)
+    worker.moveToThread(thread)
+    thread.started.connect(worker.run)
+    worker.finished.connect(_on_usb_done, Qt.ConnectionType.QueuedConnection)
+    worker.finished.connect(thread.quit)
+    thread.finished.connect(worker.deleteLater)
+    thread.finished.connect(thread.deleteLater)
+    thread.start()
+```
+
+Update the panel constructor to accept a `plugin` reference and use the real scheduler when nothing is injected:
+
+```python
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        *,
+        list_monitors=None,
+        list_usb_devices=None,
+        schedule_discovery=None,
+    ) -> None:
+        super().__init__(parent)
+        self._user_settings = UserSettings.instance()
+        self._list_monitors = list_monitors
+        self._list_usb_devices = list_usb_devices
+        self._monitors = []
+        self._usb_devices = []
+
+        self._layout = QVBoxLayout(self)
+        self._placeholder = QLabel("Reading monitor capabilities…", self)
+        self._layout.addWidget(self._placeholder)
+
+        self._monitor_groups: dict[str, dict] = {}
+        self._usb_combo: QComboBox | None = None
+
+        if schedule_discovery is not None:
+            schedule_discovery(self._populate)
+        elif list_monitors is not None or list_usb_devices is not None:
+            # Synchronous test path with explicit fakes but no scheduler.
+            self._populate()
+        else:
+            # Production: parent must be the plugin so we can reach its
+            # monitor_info_ctx and device_listener.
+            _default_schedule(self, parent)
+```
+
+- [ ] **Step 4: Run all tests to verify nothing regressed**
+
+Run: `./env/Scripts/python.exe -m pytest tests/ -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plugins/device_display_mapper/display_automation_panel.py tests/test_display_automation_panel.py
+git commit -m "feat: dispatch display-automation discovery off the GUI thread"
+```
+
+---
+
+### Task 7: Wire the panel into the plugin and remove the tray submenu
+
+**Files:**
+- Modify: `src/plugins/device_display_mapper/device_display_mapper_plugin.py`
+
+- [ ] **Step 1: Replace the menu/panel methods**
+
+Open `src/plugins/device_display_mapper/device_display_mapper_plugin.py` and replace the body of `retrieve_menus` (lines 40-63) and add `retrieve_config_panels`:
+
+```python
+    def retrieve_menus(self) -> list[QMenu | QAction]:
+        return []
+
+    def retrieve_config_panels(self) -> list[ConfigPanel]:
+        from .display_automation_panel import DisplayAutomationConfigPanel
+        return [DisplayAutomationConfigPanel(parent=self)]
+```
+
+Add the import at the top:
+
+```python
+from ...base.config_panel import ConfigPanel
+```
+
+Then delete `create_usb_selection_menu` (lines 65-78) and `create_display_selection_menu` (lines 80-95) — they have no other callers.
+
+`change_usb_watcher`, `device_changed`, `_apply_input_source`, and `closeEvent` stay untouched. The runtime hot-path still reads the same settings keys the panel writes.
+
+- [ ] **Step 2: Run the full suite**
+
+Run: `./env/Scripts/python.exe -m pytest tests/ -q`
+Expected: PASS.
+
+- [ ] **Step 3: Run flake8 the way pre-commit does**
+
+Run: `./env/Scripts/python.exe -m flake8 src/ tests/`
+Expected: clean output.
+
+- [ ] **Step 4: Manual smoke test**
+
+Kill any running tray instance:
+
+```powershell
+Get-Process | Where-Object { $_.Path -eq "$PWD\env\Scripts\python.exe" } | Stop-Process -Force
+```
+
+Launch from the dev venv:
+
+```bash
+./env/Scripts/python.exe -m src.swiss_windows_knife
+```
+
+Verify:
+- Tray icon appears within ~1 s (previously it took several seconds while DDC/CI capability strings were read).
+- Right-clicking the tray no longer shows a "Display automation" submenu.
+- Opening "Configuration…" shows a "Display automation" tab. The tab initially shows "Reading monitor capabilities…", then renders the USB combobox and per-monitor input pickers within a few seconds.
+- Selecting an input + USB device + clicking OK persists. Re-opening Configuration shows the choices preselected.
+- Plug/unplug the configured USB device — input source still switches as before (the runtime path is unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plugins/device_display_mapper/device_display_mapper_plugin.py
+git commit -m "feat: move display automation from tray menu to Configuration"
+```

--- a/src/base/cancellation.py
+++ b/src/base/cancellation.py
@@ -1,0 +1,25 @@
+import threading
+
+
+class Token:
+    """Atomic cancellation flag handed back from `submit`-style APIs.
+
+    Submitters store the token, cancel it when their receiver goes away,
+    and the runner / queue checks `is_cancelled` at the callback boundary.
+    Cancellation is one-way and idempotent.
+    """
+
+    __slots__ = ("_cancelled", "_lock")
+
+    def __init__(self) -> None:
+        self._cancelled = False
+        self._lock = threading.Lock()
+
+    def cancel(self) -> None:
+        with self._lock:
+            self._cancelled = True
+
+    @property
+    def is_cancelled(self) -> bool:
+        with self._lock:
+            return self._cancelled

--- a/src/base/config_panel.py
+++ b/src/base/config_panel.py
@@ -14,3 +14,13 @@ class ConfigPanel(QWidget):
 
     def apply(self) -> bool:
         return True
+
+    def cleanup(self) -> None:
+        """Called by `ConfigurationDialog` once when the dialog is closing
+        (OK, Cancel, or X), *before* Qt's parent-child destruction cascade.
+
+        Override to cancel in-flight async work whose callbacks would emit
+        on widgets that are about to be torn down. Tests don't need to call
+        this; production wiring goes through `ConfigurationDialog.done`.
+        """
+        return None

--- a/src/base/monitor_runner.py
+++ b/src/base/monitor_runner.py
@@ -3,6 +3,8 @@ import queue
 import threading
 from collections.abc import Callable
 
+from .cancellation import Token
+
 
 class _MonitorRunner:
     def __init__(self) -> None:
@@ -10,12 +12,23 @@ class _MonitorRunner:
         self._thread = threading.Thread(target=self._run, daemon=True, name="MonitorRunner")
         self._thread.start()
 
-    def submit(self, fn: Callable, *args, **kwargs) -> None:
-        self._queue.put((fn, args, kwargs))
+    def submit(self, fn: Callable, *args, **kwargs) -> Token:
+        """Submit work; returns a token the caller can cancel.
+
+        If the token is cancelled before the worker dequeues this entry, `fn`
+        is skipped entirely. Once `fn` starts running it can't be aborted —
+        but `fn` itself may consult the token to skip side effects (e.g.,
+        emitting back into a Qt object that is being destroyed).
+        """
+        token = Token()
+        self._queue.put((fn, args, kwargs, token))
+        return token
 
     def _run(self) -> None:
         while True:
-            fn, args, kwargs = self._queue.get()
+            fn, args, kwargs, token = self._queue.get()
+            if token.is_cancelled:
+                continue
             try:
                 fn(*args, **kwargs)
             except Exception:

--- a/src/base/persistent_dialog.py
+++ b/src/base/persistent_dialog.py
@@ -1,4 +1,4 @@
-from PySide6.QtCore import QSize
+from PySide6.QtCore import QSize, Qt
 from PySide6.QtWidgets import QDialog, QWidget
 
 from .user_settings import UserSettings
@@ -20,6 +20,19 @@ class PersistentSizeDialog(QDialog):
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._user_settings = UserSettings.instance()
+        # Promote from Qt.Dialog (no taskbar entry on Windows) to Qt.Window
+        # so this dialog gets its own taskbar button + the app icon while
+        # the tray's hidden TrayWidget would otherwise leave it iconless.
+        # Set flags explicitly because Qt.Dialog has the Qt.Window bit
+        # baked in — toggling the Dialog bit alone strips Window too.
+        self.setWindowFlags(
+            Qt.WindowType.Window
+            | Qt.WindowType.WindowTitleHint
+            | Qt.WindowType.WindowSystemMenuHint
+            | Qt.WindowType.WindowCloseButtonHint
+            | Qt.WindowType.WindowMinimizeButtonHint
+            | Qt.WindowType.WindowMaximizeButtonHint
+        )
 
     def restore_size(self, default: QSize) -> None:
         if not self.size_settings_prefix:

--- a/src/plugins/device_display_mapper/device_display_mapper_plugin.py
+++ b/src/plugins/device_display_mapper/device_display_mapper_plugin.py
@@ -1,13 +1,13 @@
 import logging
 import time
-from functools import partial
 
 import monitorcontrol
 from PySide6.QtCore import Slot
-from PySide6.QtGui import QAction, QActionGroup
+from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QMenu, QWidget
 
 from ...base.base_widget import BaseWidget
+from ...base.config_panel import ConfigPanel
 from ...base.monitor_runner import runner
 from ...base.user_settings import UserSettings
 from .device_listener import Device, DeviceListener, DeviceNotificationType
@@ -38,64 +38,11 @@ class DeviceDisplayMapperPlugin(BaseWidget):
         self.device_listener.change_detected.connect(self.device_changed)
 
     def retrieve_menus(self) -> list[QMenu | QAction]:
-        menu = QMenu('Display automation', self)
+        return []
 
-        sub_menus = []
-        for monitor in monitorcontrol.get_monitors():
-            with monitor:
-                monitor_info = self.monitor_info_ctx.get_monitor_info_by_monitor(monitor=monitor)
-                if monitor_info is None:
-                    logging.warning('No monitor info not available')
-                    continue
-                monitor_label = f'{monitor_info.model} ({monitor_info.device_name})'
-                sub_menus.extend([
-                    self.create_display_selection_menu(
-                        f'Input for {monitor_label} on connect',
-                        monitor_info.inputs,
-                        USER_SETTINGS_DISPLAY_ON_CONNECT_KEY_FUNC(monitor_info.device_id)),
-                    self.create_display_selection_menu(
-                        f'Input for {monitor_label} on disconnect',
-                        monitor_info.inputs,
-                        USER_SETTINGS_DISPLAY_ON_DISCONNECT_KEY_FUNC(monitor_info.device_id))])
-        sub_menus.append(self.create_usb_selection_menu())
-        for sub_menu in sub_menus:
-            menu.addMenu(sub_menu)
-        return [menu]
-
-    def create_usb_selection_menu(self):
-        menu = QMenu('USB trigger for display switch', self)
-        group = QActionGroup(self)
-        group.setExclusive(True)
-        for device in self.device_listener.get_real_usb_devices():
-            action = QAction(f'{device.name}, {device.description} ({device.id})', self)
-            action.setCheckable(True)
-            action.setData(device)
-            action.triggered.connect(partial(lambda val: self.change_usb_watcher(val), val=device))
-            if device.id == self.user_settings.get(USER_SETTINGS_DISPLAY_USB_WATCHER_KEY):
-                action.setChecked(True)
-            group.addAction(action)
-            menu.addAction(action)
-        return menu
-
-    def create_display_selection_menu(self, title, monitor_inputs, device_id_key):
-        menu = QMenu(title, self)
-        group = QActionGroup(self)
-        group.setExclusive(True)
-
-        for monitor_input in monitor_inputs:
-            action = QAction(str(monitor_input), self)
-            action.setCheckable(True)
-            action.triggered.connect(partial(
-                lambda val: self.user_settings.set(device_id_key, val),
-                val=monitor_input))
-            if monitor_input == self.user_settings.get(device_id_key):
-                action.setChecked(True)
-            group.addAction(action)
-            menu.addAction(action)
-        return menu
-
-    def change_usb_watcher(self, device: Device):
-        self.user_settings.set(USER_SETTINGS_DISPLAY_USB_WATCHER_KEY, device.id)
+    def retrieve_config_panels(self) -> list[ConfigPanel]:
+        from .display_automation_panel import DisplayAutomationConfigPanel
+        return [DisplayAutomationConfigPanel(parent=self)]
 
     @Slot(object, object)
     def device_changed(self, device_notification_type: DeviceNotificationType, usb_device: Device):

--- a/src/plugins/device_display_mapper/device_display_mapper_plugin.py
+++ b/src/plugins/device_display_mapper/device_display_mapper_plugin.py
@@ -8,6 +8,7 @@ from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QMenu, QWidget
 
 from ...base.base_widget import BaseWidget
+from ...base.cancellation import Token
 from ...base.config_panel import ConfigPanel
 from ...base.monitor_runner import runner
 from ...base.user_settings import UserSettings
@@ -40,7 +41,7 @@ class DeviceDisplayMapperPlugin(BaseWidget):
         self.device_listener.change_detected.connect(self.device_changed)
 
         self._usb_device_cache: list[Device] | None = None
-        self._usb_fetch_callbacks: list[Callable[[list[Device]], None]] = []
+        self._usb_fetch_subscriptions: list[tuple[Token, Callable[[list[Device]], None]]] = []
         self._usb_fetch_thread: QThread | None = None
 
     def retrieve_menus(self) -> list[QMenu | QAction]:
@@ -50,24 +51,30 @@ class DeviceDisplayMapperPlugin(BaseWidget):
         from .display_automation_panel import DisplayAutomationConfigPanel
         return [DisplayAutomationConfigPanel(parent=self)]
 
-    def request_usb_devices(self, callback: Callable[[list[Device]], None]) -> None:
+    def request_usb_devices(self, callback: Callable[[list[Device]], None]) -> Token:
         """Provide the USB device list to `callback` on the GUI thread.
 
-        Returns the cached list immediately (via a 0-ms QTimer to keep
-        delivery asynchronous and predictable for callers). Otherwise
-        dispatches a single `UsbWorker` on its own QThread (or joins an
-        in-flight fetch) and fires every queued callback when results
-        arrive. Cache is invalidated on every USB hot-plug event so the
-        next request re-enumerates.
+        Returns a `Token`; if the caller cancels it (e.g., from the panel's
+        `destroyed` signal) the callback is suppressed even if results have
+        already arrived. Cached lists are delivered via `QTimer.singleShot`
+        so all paths are reliably asynchronous; cold lookups dispatch a
+        single `UsbWorker` (or join an in-flight fetch). The cache is
+        invalidated on every USB hot-plug event so the next request
+        re-enumerates.
         """
+        token = Token()
         if self._usb_device_cache is not None:
             cached = list(self._usb_device_cache)
-            QTimer.singleShot(0, lambda: callback(cached))
-            return
 
-        self._usb_fetch_callbacks.append(callback)
+            def _deliver_cached() -> None:
+                if not token.is_cancelled:
+                    callback(cached)
+            QTimer.singleShot(0, _deliver_cached)
+            return token
+
+        self._usb_fetch_subscriptions.append((token, callback))
         if self._usb_fetch_thread is not None:
-            return  # already in flight; will fire all callbacks when done
+            return token  # already in flight; we'll fire when results land
 
         thread = QThread(self)
         worker = UsbWorker()
@@ -83,18 +90,18 @@ class DeviceDisplayMapperPlugin(BaseWidget):
         thread._usb_worker_anchor = worker  # type: ignore[attr-defined]
         thread.start()
         self._usb_fetch_thread = thread
+        return token
 
     @Slot(list)
     def _on_usb_fetched(self, devices: list) -> None:
         self._usb_device_cache = list(devices)
-        callbacks = self._usb_fetch_callbacks
-        self._usb_fetch_callbacks = []
+        subscriptions = self._usb_fetch_subscriptions
+        self._usb_fetch_subscriptions = []
         self._usb_fetch_thread = None
-        for cb in callbacks:
-            try:
-                cb(list(devices))
-            except Exception:
-                logging.exception("USB fetch callback failed")
+        for token, cb in subscriptions:
+            if token.is_cancelled:
+                continue
+            cb(list(devices))
 
     @Slot(object, object)
     def device_changed(self, device_notification_type: DeviceNotificationType, usb_device: Device):

--- a/src/plugins/device_display_mapper/device_display_mapper_plugin.py
+++ b/src/plugins/device_display_mapper/device_display_mapper_plugin.py
@@ -1,8 +1,9 @@
 import logging
 import time
+from collections.abc import Callable
 
 import monitorcontrol
-from PySide6.QtCore import Slot
+from PySide6.QtCore import Qt, QThread, QTimer, Slot
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QMenu, QWidget
 
@@ -11,6 +12,7 @@ from ...base.config_panel import ConfigPanel
 from ...base.monitor_runner import runner
 from ...base.user_settings import UserSettings
 from .device_listener import Device, DeviceListener, DeviceNotificationType
+from .discovery import UsbWorker
 from .monitor_info import MonitorInfoCtx
 
 USER_SETTINGS_DISPLAY_USB_WATCHER_KEY = 'display_usb_watcher'
@@ -37,6 +39,10 @@ class DeviceDisplayMapperPlugin(BaseWidget):
         self.device_listener = DeviceListener(self)
         self.device_listener.change_detected.connect(self.device_changed)
 
+        self._usb_device_cache: list[Device] | None = None
+        self._usb_fetch_callbacks: list[Callable[[list[Device]], None]] = []
+        self._usb_fetch_thread: QThread | None = None
+
     def retrieve_menus(self) -> list[QMenu | QAction]:
         return []
 
@@ -44,9 +50,58 @@ class DeviceDisplayMapperPlugin(BaseWidget):
         from .display_automation_panel import DisplayAutomationConfigPanel
         return [DisplayAutomationConfigPanel(parent=self)]
 
+    def request_usb_devices(self, callback: Callable[[list[Device]], None]) -> None:
+        """Provide the USB device list to `callback` on the GUI thread.
+
+        Returns the cached list immediately (via a 0-ms QTimer to keep
+        delivery asynchronous and predictable for callers). Otherwise
+        dispatches a single `UsbWorker` on its own QThread (or joins an
+        in-flight fetch) and fires every queued callback when results
+        arrive. Cache is invalidated on every USB hot-plug event so the
+        next request re-enumerates.
+        """
+        if self._usb_device_cache is not None:
+            cached = list(self._usb_device_cache)
+            QTimer.singleShot(0, lambda: callback(cached))
+            return
+
+        self._usb_fetch_callbacks.append(callback)
+        if self._usb_fetch_thread is not None:
+            return  # already in flight; will fire all callbacks when done
+
+        thread = QThread(self)
+        worker = UsbWorker()
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+        worker.finished.connect(self._on_usb_fetched, Qt.ConnectionType.QueuedConnection)
+        worker.finished.connect(thread.quit)
+        thread.finished.connect(worker.deleteLater)
+        thread.finished.connect(thread.deleteLater)
+        # Anchor the worker against PySide6 GC: signal connections are
+        # weak-ref'd, so without this the worker can be collected before
+        # `started` fires and `run` would silently never execute.
+        thread._usb_worker_anchor = worker  # type: ignore[attr-defined]
+        thread.start()
+        self._usb_fetch_thread = thread
+
+    @Slot(list)
+    def _on_usb_fetched(self, devices: list) -> None:
+        self._usb_device_cache = list(devices)
+        callbacks = self._usb_fetch_callbacks
+        self._usb_fetch_callbacks = []
+        self._usb_fetch_thread = None
+        for cb in callbacks:
+            try:
+                cb(list(devices))
+            except Exception:
+                logging.exception("USB fetch callback failed")
+
     @Slot(object, object)
     def device_changed(self, device_notification_type: DeviceNotificationType, usb_device: Device):
         logging.debug(f'Device change detected ({device_notification_type}): {usb_device.id}')
+        # Any USB topology change invalidates the cached device list so the
+        # next time the configuration panel is opened, it re-enumerates.
+        self._usb_device_cache = None
         current_time = time.time()
         if current_time - self.last_changed < 1.0:
             return

--- a/src/plugins/device_display_mapper/device_display_mapper_plugin.py
+++ b/src/plugins/device_display_mapper/device_display_mapper_plugin.py
@@ -13,7 +13,7 @@ from ...base.config_panel import ConfigPanel
 from ...base.monitor_runner import runner
 from ...base.user_settings import UserSettings
 from .device_listener import Device, DeviceListener, DeviceNotificationType
-from .discovery import UsbWorker
+from .discovery import UsbWorker, list_monitors
 from .monitor_info import MonitorInfoCtx
 
 USER_SETTINGS_DISPLAY_USB_WATCHER_KEY = 'display_usb_watcher'
@@ -43,6 +43,20 @@ class DeviceDisplayMapperPlugin(BaseWidget):
         self._usb_device_cache: list[Device] | None = None
         self._usb_fetch_subscriptions: list[tuple[Token, Callable[[list[Device]], None]]] = []
         self._usb_fetch_thread: QThread | None = None
+
+        # Pre-warm both caches in the background so the first time the user
+        # opens Configuration the panel populates instantly. Both calls
+        # schedule work off the GUI thread (runner / QThread) and return
+        # immediately; results land in `monitor_info_ctx` and the USB
+        # cache. No-op callback because no live receiver is interested yet.
+        runner().submit(self._prewarm_monitor_cache)
+        self.request_usb_devices(lambda _devices: None)
+
+    def _prewarm_monitor_cache(self) -> None:
+        try:
+            list_monitors(self.monitor_info_ctx)
+        except Exception:
+            logging.exception("Monitor cache pre-warm failed")
 
     def retrieve_menus(self) -> list[QMenu | QAction]:
         return []

--- a/src/plugins/device_display_mapper/discovery.py
+++ b/src/plugins/device_display_mapper/discovery.py
@@ -1,8 +1,8 @@
 import logging
 
 import monitorcontrol
+from PySide6.QtCore import QObject, Signal
 
-from .device_listener import DeviceListener
 from .monitor_info import MonitorInfo, MonitorInfoCtx
 
 
@@ -11,7 +11,7 @@ def list_monitors(monitor_info_ctx: MonitorInfoCtx) -> list[MonitorInfo]:
 
     MUST run on the dedicated monitor-runner thread (see
     `src/base/monitor_runner.py`); calling from the GUI thread will block
-    for seconds per monitor.
+    for seconds per monitor on a cold cache.
     """
     out: list[MonitorInfo] = []
     for monitor in monitorcontrol.get_monitors():
@@ -24,9 +24,34 @@ def list_monitors(monitor_info_ctx: MonitorInfoCtx) -> list[MonitorInfo]:
     return out
 
 
-def list_usb_devices(device_listener: DeviceListener):
-    """Enumerate currently-attached real USB devices via WMI.
+class UsbWorker(QObject):
+    """One-shot WMI Win32_PnPEntity enumeration on a worker thread.
 
-    MUST run off the GUI thread; `Win32_PnPEntity` enumeration is multi-second.
+    Each instance runs once: `moveToThread(thread)`, connect `thread.started`
+    to `run`, start the thread; emits `finished(list[Device])` when done.
+    `run` initialises COM on the worker thread (the GUI-thread `wmi.WMI()`
+    instance can't be used cross-thread without crashing).
     """
-    return device_listener.get_real_usb_devices()
+
+    finished = Signal(list)
+
+    def run(self) -> None:
+        import pythoncom
+        import wmi
+
+        from .device_listener import Device, DeviceListener
+        pythoncom.CoInitialize()
+        try:
+            local_wmi = wmi.WMI()
+            devices: list[Device] = []
+            for entity in local_wmi.Win32_PnPEntity():
+                pnp_id = getattr(entity, "PNPDeviceID", "")
+                if DeviceListener.is_real_usb_device(pnp_id):
+                    devices.append(Device(entity.DeviceID, entity.Name, entity.Description, entity.Manufacturer))
+            devices.sort(key=lambda d: d.name)
+        except Exception:
+            logging.exception("USB discovery failed")
+            devices = []
+        finally:
+            pythoncom.CoUninitialize()
+        self.finished.emit(devices)

--- a/src/plugins/device_display_mapper/discovery.py
+++ b/src/plugins/device_display_mapper/discovery.py
@@ -1,0 +1,32 @@
+import logging
+
+import monitorcontrol
+
+from .device_listener import DeviceListener
+from .monitor_info import MonitorInfo, MonitorInfoCtx
+
+
+def list_monitors(monitor_info_ctx: MonitorInfoCtx) -> list[MonitorInfo]:
+    """Read DDC/CI capabilities for every attached monitor.
+
+    MUST run on the dedicated monitor-runner thread (see
+    `src/base/monitor_runner.py`); calling from the GUI thread will block
+    for seconds per monitor.
+    """
+    out: list[MonitorInfo] = []
+    for monitor in monitorcontrol.get_monitors():
+        with monitor:
+            info = monitor_info_ctx.get_monitor_info_by_monitor(monitor=monitor)
+            if info is None:
+                logging.warning("No monitor info available for one of the attached displays")
+                continue
+            out.append(info)
+    return out
+
+
+def list_usb_devices(device_listener: DeviceListener):
+    """Enumerate currently-attached real USB devices via WMI.
+
+    MUST run off the GUI thread; `Win32_PnPEntity` enumeration is multi-second.
+    """
+    return device_listener.get_real_usb_devices()

--- a/src/plugins/device_display_mapper/display_automation_panel.py
+++ b/src/plugins/device_display_mapper/display_automation_panel.py
@@ -1,10 +1,12 @@
 from collections.abc import Callable
 from typing import Any
 
-from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+from PySide6.QtWidgets import QComboBox, QFormLayout, QGroupBox, QLabel, QVBoxLayout, QWidget
 
 from ...base.config_panel import ConfigPanel
 from ...base.user_settings import UserSettings
+
+USB_WATCHER_KEY = 'display_usb_watcher'
 
 
 class DisplayAutomationConfigPanel(ConfigPanel):
@@ -33,7 +35,7 @@ class DisplayAutomationConfigPanel(ConfigPanel):
         self._layout.addWidget(self._placeholder)
 
         self._monitor_groups: dict[str, dict] = {}
-        self._usb_combo = None
+        self._usb_combo: QComboBox | None = None
 
         if list_monitors is not None or list_usb_devices is not None:
             self._schedule(self._populate)
@@ -41,7 +43,32 @@ class DisplayAutomationConfigPanel(ConfigPanel):
     def _populate(self) -> None:
         self._monitors = list(self._list_monitors()) if self._list_monitors else []
         self._usb_devices = list(self._list_usb_devices()) if self._list_usb_devices else []
-        # Widgets are added in Task 5; for now the placeholder stays.
+
+        self._placeholder.hide()
+        self._build_usb_section()
+
+    def _build_usb_section(self) -> None:
+        box = QGroupBox("USB trigger for display switch", self)
+        form = QFormLayout(box)
+
+        combo = QComboBox(box)
+        combo.addItem("(none)", userData=None)
+        for device in self._usb_devices:
+            label = f"{device.name} ({device.id})"
+            combo.addItem(label, userData=device.id)
+
+        current = self._user_settings.get(USB_WATCHER_KEY)
+        if current is not None:
+            for i in range(combo.count()):
+                if combo.itemData(i) == current:
+                    combo.setCurrentIndex(i)
+                    break
+
+        form.addRow("Watch:", combo)
+        self._usb_combo = combo
+        self._layout.addWidget(box)
 
     def apply(self) -> bool:
+        if self._usb_combo is not None:
+            self._user_settings.set(USB_WATCHER_KEY, self._usb_combo.currentData())
         return True

--- a/src/plugins/device_display_mapper/display_automation_panel.py
+++ b/src/plugins/device_display_mapper/display_automation_panel.py
@@ -1,10 +1,15 @@
+import logging
 from collections.abc import Callable
 from typing import Any
 
+from PySide6.QtCore import QObject, Qt, QThread, Signal
 from PySide6.QtWidgets import QComboBox, QFormLayout, QGroupBox, QLabel, QVBoxLayout, QWidget
 
 from ...base.config_panel import ConfigPanel
+from ...base.monitor_runner import runner
 from ...base.user_settings import UserSettings
+from .discovery import list_monitors as _list_monitors_default
+from .discovery import list_usb_devices as _list_usb_devices_default
 
 USB_WATCHER_KEY = 'display_usb_watcher'
 ON_CONNECT_KEY_PREFIX = 'display_on_connect_'
@@ -41,8 +46,15 @@ class DisplayAutomationConfigPanel(ConfigPanel):
         self._monitor_groups: dict[str, dict] = {}
         self._usb_combo: QComboBox | None = None
 
-        if list_monitors is not None or list_usb_devices is not None:
-            self._schedule(self._populate)
+        if schedule_discovery is not None:
+            schedule_discovery(self._populate)
+        elif list_monitors is not None or list_usb_devices is not None:
+            # Test path with explicit fakes — populate inline.
+            self._populate()
+        else:
+            # Production: parent must be the plugin so we can reach its
+            # monitor_info_ctx and device_listener.
+            _default_schedule(self, parent)
 
     def _populate(self) -> None:
         self._monitors = list(self._list_monitors()) if self._list_monitors else []
@@ -118,3 +130,83 @@ class DisplayAutomationConfigPanel(ConfigPanel):
                     continue
                 self._user_settings.set(key_prefix + device_id, data)
         return True
+
+
+class _DiscoveryBridge(QObject):
+    """Marshals discovery results from the runner / worker threads back to GUI."""
+
+    monitors_ready = Signal(list)
+
+    def __init__(self, panel: "DisplayAutomationConfigPanel") -> None:
+        super().__init__(panel)
+        self._panel = panel
+        self._monitors: list | None = None
+        self._usb: list | None = None
+        self.monitors_ready.connect(self._on_monitors, Qt.ConnectionType.QueuedConnection)
+
+    def _on_monitors(self, monitors: list) -> None:
+        self._monitors = monitors
+        self._maybe_finalize()
+
+    def _on_usb(self, devices: list) -> None:
+        self._usb = devices
+        self._maybe_finalize()
+
+    def _maybe_finalize(self) -> None:
+        if self._monitors is None or self._usb is None:
+            return
+        self._panel._monitors = self._monitors
+        self._panel._usb_devices = self._usb
+        self._panel._placeholder.hide()
+        self._panel._build_usb_section()
+        for info in self._panel._monitors:
+            self._panel._build_monitor_section(info)
+
+
+class _UsbWorker(QObject):
+    finished = Signal(list)
+
+    def __init__(self, device_listener) -> None:
+        super().__init__()
+        self._device_listener = device_listener
+
+    def run(self) -> None:
+        try:
+            devices = list(_list_usb_devices_default(self._device_listener))
+        except Exception:
+            logging.exception("USB discovery failed")
+            devices = []
+        self.finished.emit(devices)
+
+
+def _default_schedule(panel: "DisplayAutomationConfigPanel", plugin) -> None:
+    """Real-world scheduler: monitor discovery on `runner()`, USB on a QThread.
+
+    Both results land back on the GUI thread via queued Qt signals so the
+    panel can rebuild widgets safely.
+    """
+    bridge = _DiscoveryBridge(panel)
+
+    def _read_monitors() -> None:
+        try:
+            monitors = _list_monitors_default(plugin.monitor_info_ctx)
+        except Exception:
+            logging.exception("Monitor discovery failed")
+            monitors = []
+        try:
+            bridge.monitors_ready.emit(monitors)
+        except RuntimeError:
+            # Bridge was destroyed (e.g., user closed Configuration mid-discovery).
+            logging.debug("Discovery bridge gone before monitor results landed")
+
+    runner().submit(_read_monitors)
+
+    thread = QThread(panel)
+    worker = _UsbWorker(plugin.device_listener)
+    worker.moveToThread(thread)
+    thread.started.connect(worker.run)
+    worker.finished.connect(bridge._on_usb, Qt.ConnectionType.QueuedConnection)
+    worker.finished.connect(thread.quit)
+    thread.finished.connect(worker.deleteLater)
+    thread.finished.connect(thread.deleteLater)
+    thread.start()

--- a/src/plugins/device_display_mapper/display_automation_panel.py
+++ b/src/plugins/device_display_mapper/display_automation_panel.py
@@ -7,6 +7,10 @@ from ...base.config_panel import ConfigPanel
 from ...base.user_settings import UserSettings
 
 USB_WATCHER_KEY = 'display_usb_watcher'
+ON_CONNECT_KEY_PREFIX = 'display_on_connect_'
+ON_DISCONNECT_KEY_PREFIX = 'display_on_disconnect_'
+
+UNCHANGED_LABEL = "(unchanged)"
 
 
 class DisplayAutomationConfigPanel(ConfigPanel):
@@ -46,6 +50,38 @@ class DisplayAutomationConfigPanel(ConfigPanel):
 
         self._placeholder.hide()
         self._build_usb_section()
+        for info in self._monitors:
+            self._build_monitor_section(info)
+
+    def _build_monitor_section(self, info) -> None:
+        box = QGroupBox(f"{info.model} ({info.device_name})", self)
+        form = QFormLayout(box)
+
+        connect_combo = self._make_input_combo(info.inputs, info.device_id, ON_CONNECT_KEY_PREFIX, box)
+        disconnect_combo = self._make_input_combo(info.inputs, info.device_id, ON_DISCONNECT_KEY_PREFIX, box)
+
+        form.addRow("On USB connect:", connect_combo)
+        form.addRow("On USB disconnect:", disconnect_combo)
+
+        self._monitor_groups[info.device_id] = {
+            "connect_combo": connect_combo,
+            "disconnect_combo": disconnect_combo,
+        }
+        self._layout.addWidget(box)
+
+    def _make_input_combo(self, inputs, device_id, key_prefix, parent) -> QComboBox:
+        combo = QComboBox(parent)
+        combo.addItem(UNCHANGED_LABEL, userData=None)
+        for entry in inputs:
+            combo.addItem(str(entry), userData=entry)
+
+        current = self._user_settings.get(key_prefix + device_id)
+        if current is not None:
+            for i in range(combo.count()):
+                if str(combo.itemData(i)) == str(current):
+                    combo.setCurrentIndex(i)
+                    break
+        return combo
 
     def _build_usb_section(self) -> None:
         box = QGroupBox("USB trigger for display switch", self)
@@ -71,4 +107,14 @@ class DisplayAutomationConfigPanel(ConfigPanel):
     def apply(self) -> bool:
         if self._usb_combo is not None:
             self._user_settings.set(USB_WATCHER_KEY, self._usb_combo.currentData())
+        for device_id, widgets in self._monitor_groups.items():
+            for key_prefix, combo_key in (
+                (ON_CONNECT_KEY_PREFIX, "connect_combo"),
+                (ON_DISCONNECT_KEY_PREFIX, "disconnect_combo"),
+            ):
+                data = widgets[combo_key].currentData()
+                if data is None:
+                    # "(unchanged)" — leave existing setting alone.
+                    continue
+                self._user_settings.set(key_prefix + device_id, data)
         return True

--- a/src/plugins/device_display_mapper/display_automation_panel.py
+++ b/src/plugins/device_display_mapper/display_automation_panel.py
@@ -1,0 +1,47 @@
+from collections.abc import Callable
+from typing import Any
+
+from PySide6.QtWidgets import QLabel, QVBoxLayout, QWidget
+
+from ...base.config_panel import ConfigPanel
+from ...base.user_settings import UserSettings
+
+
+class DisplayAutomationConfigPanel(ConfigPanel):
+
+    title = "Display automation"
+
+    def __init__(
+        self,
+        parent: QWidget | None = None,
+        *,
+        list_monitors: Callable[[], list[Any]] | None = None,
+        list_usb_devices: Callable[[], list[Any]] | None = None,
+        schedule_discovery: Callable[[Callable[[], None]], None] | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._user_settings = UserSettings.instance()
+        self._list_monitors = list_monitors
+        self._list_usb_devices = list_usb_devices
+        self._schedule = schedule_discovery or (lambda fn: fn())
+
+        self._monitors: list[Any] = []
+        self._usb_devices: list[Any] = []
+
+        self._layout = QVBoxLayout(self)
+        self._placeholder = QLabel("Reading monitor capabilities…", self)
+        self._layout.addWidget(self._placeholder)
+
+        self._monitor_groups: dict[str, dict] = {}
+        self._usb_combo = None
+
+        if list_monitors is not None or list_usb_devices is not None:
+            self._schedule(self._populate)
+
+    def _populate(self) -> None:
+        self._monitors = list(self._list_monitors()) if self._list_monitors else []
+        self._usb_devices = list(self._list_usb_devices()) if self._list_usb_devices else []
+        # Widgets are added in Task 5; for now the placeholder stays.
+
+    def apply(self) -> bool:
+        return True

--- a/src/plugins/device_display_mapper/display_automation_panel.py
+++ b/src/plugins/device_display_mapper/display_automation_panel.py
@@ -44,6 +44,7 @@ class DisplayAutomationConfigPanel(ConfigPanel):
 
         self._monitor_groups: dict[str, dict] = {}
         self._usb_combo: QComboBox | None = None
+        self._cleanup_callbacks: list[Callable[[], None]] = []
 
         if schedule_discovery is not None:
             schedule_discovery(self._populate)
@@ -130,28 +131,66 @@ class DisplayAutomationConfigPanel(ConfigPanel):
                 self._user_settings.set(key_prefix + device_id, data)
         return True
 
+    def cleanup(self) -> None:
+        for cb in self._cleanup_callbacks:
+            cb()
+        self._cleanup_callbacks.clear()
+
 
 class _DiscoveryBridge(QObject):
-    """Marshals discovery results from the runner / worker threads back to GUI."""
+    """Marshals discovery results from the runner / worker threads back to GUI.
+
+    Parented to the long-lived plugin (not the panel) so workers can always
+    emit on it without RuntimeError. When the panel dies, the bridge nulls
+    its panel reference, drops any not-yet-arrived results, and self-deletes
+    once both work paths have settled. Token cancellation at the runner
+    queue level skips queued (but not-yet-started) work to avoid wasting
+    cycles on results nobody will use.
+    """
 
     monitors_ready = Signal(list)
 
-    def __init__(self, panel: "DisplayAutomationConfigPanel") -> None:
-        super().__init__(panel)
-        self._panel = panel
+    def __init__(self, panel: "DisplayAutomationConfigPanel", plugin: QObject) -> None:
+        super().__init__(plugin)
+        self._panel: DisplayAutomationConfigPanel | None = panel
         self._monitors: list | None = None
         self._usb: list | None = None
+        self._monitor_pending = True
+        self._usb_pending = True
+        self._monitor_token = None
+        self._usb_token = None
         self.monitors_ready.connect(self._on_monitors, Qt.ConnectionType.QueuedConnection)
+        # `panel.destroyed` fires synchronously inside the panel's destructor
+        # on the GUI thread; bridge stays alive to absorb in-flight results.
+        panel.destroyed.connect(self._on_panel_destroyed)
+
+    def attach_tokens(self, monitor_token, usb_token) -> None:
+        self._monitor_token = monitor_token
+        self._usb_token = usb_token
+
+    def _on_panel_destroyed(self) -> None:
+        self._panel = None
+        if self._monitor_token is not None:
+            self._monitor_token.cancel()
+        if self._usb_token is not None:
+            self._usb_token.cancel()
+        self._reap_if_settled()
 
     def _on_monitors(self, monitors: list) -> None:
         self._monitors = monitors
+        self._monitor_pending = False
         self._maybe_finalize()
+        self._reap_if_settled()
 
     def _on_usb(self, devices: list) -> None:
         self._usb = devices
+        self._usb_pending = False
         self._maybe_finalize()
+        self._reap_if_settled()
 
     def _maybe_finalize(self) -> None:
+        if self._panel is None:
+            return
         if self._monitors is None or self._usb is None:
             return
         self._panel._monitors = self._monitors
@@ -161,13 +200,19 @@ class _DiscoveryBridge(QObject):
         for info in self._panel._monitors:
             self._panel._build_monitor_section(info)
 
+    def _reap_if_settled(self) -> None:
+        if self._panel is None and not self._monitor_pending and not self._usb_pending:
+            self.deleteLater()
+
 
 def _default_schedule(panel: "DisplayAutomationConfigPanel", plugin) -> None:
     """Real-world scheduler: monitor discovery on `runner()`, USB via the
-    plugin's cached `request_usb_devices`. Both results land back on the GUI
-    thread via queued Qt signals so the panel can rebuild widgets safely.
+    plugin's cached `request_usb_devices`. Bridge is parented to the plugin
+    so it outlives the panel; tokens cancel queued-but-unstarted work when
+    the panel goes away; in-flight work is allowed to complete and is then
+    silently dropped by the bridge.
     """
-    bridge = _DiscoveryBridge(panel)
+    bridge = _DiscoveryBridge(panel, plugin)
 
     def _read_monitors() -> None:
         try:
@@ -175,10 +220,9 @@ def _default_schedule(panel: "DisplayAutomationConfigPanel", plugin) -> None:
         except Exception:
             logging.exception("Monitor discovery failed")
             monitors = []
-        try:
-            bridge.monitors_ready.emit(monitors)
-        except RuntimeError:
-            logging.debug("Discovery bridge gone before monitor results landed")
+        bridge.monitors_ready.emit(monitors)
 
-    runner().submit(_read_monitors)
-    plugin.request_usb_devices(bridge._on_usb)
+    monitor_token = runner().submit(_read_monitors)
+    usb_token = plugin.request_usb_devices(bridge._on_usb)
+    bridge.attach_tokens(monitor_token, usb_token)
+    panel._cleanup_callbacks.append(lambda: (monitor_token.cancel(), usb_token.cancel()))

--- a/src/plugins/device_display_mapper/display_automation_panel.py
+++ b/src/plugins/device_display_mapper/display_automation_panel.py
@@ -2,14 +2,13 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-from PySide6.QtCore import QObject, Qt, QThread, Signal
+from PySide6.QtCore import QObject, Qt, Signal
 from PySide6.QtWidgets import QComboBox, QFormLayout, QGroupBox, QLabel, QVBoxLayout, QWidget
 
 from ...base.config_panel import ConfigPanel
 from ...base.monitor_runner import runner
 from ...base.user_settings import UserSettings
 from .discovery import list_monitors as _list_monitors_default
-from .discovery import list_usb_devices as _list_usb_devices_default
 
 USB_WATCHER_KEY = 'display_usb_watcher'
 ON_CONNECT_KEY_PREFIX = 'display_on_connect_'
@@ -163,27 +162,10 @@ class _DiscoveryBridge(QObject):
             self._panel._build_monitor_section(info)
 
 
-class _UsbWorker(QObject):
-    finished = Signal(list)
-
-    def __init__(self, device_listener) -> None:
-        super().__init__()
-        self._device_listener = device_listener
-
-    def run(self) -> None:
-        try:
-            devices = list(_list_usb_devices_default(self._device_listener))
-        except Exception:
-            logging.exception("USB discovery failed")
-            devices = []
-        self.finished.emit(devices)
-
-
 def _default_schedule(panel: "DisplayAutomationConfigPanel", plugin) -> None:
-    """Real-world scheduler: monitor discovery on `runner()`, USB on a QThread.
-
-    Both results land back on the GUI thread via queued Qt signals so the
-    panel can rebuild widgets safely.
+    """Real-world scheduler: monitor discovery on `runner()`, USB via the
+    plugin's cached `request_usb_devices`. Both results land back on the GUI
+    thread via queued Qt signals so the panel can rebuild widgets safely.
     """
     bridge = _DiscoveryBridge(panel)
 
@@ -196,17 +178,7 @@ def _default_schedule(panel: "DisplayAutomationConfigPanel", plugin) -> None:
         try:
             bridge.monitors_ready.emit(monitors)
         except RuntimeError:
-            # Bridge was destroyed (e.g., user closed Configuration mid-discovery).
             logging.debug("Discovery bridge gone before monitor results landed")
 
     runner().submit(_read_monitors)
-
-    thread = QThread(panel)
-    worker = _UsbWorker(plugin.device_listener)
-    worker.moveToThread(thread)
-    thread.started.connect(worker.run)
-    worker.finished.connect(bridge._on_usb, Qt.ConnectionType.QueuedConnection)
-    worker.finished.connect(thread.quit)
-    thread.finished.connect(worker.deleteLater)
-    thread.finished.connect(thread.deleteLater)
-    thread.start()
+    plugin.request_usb_devices(bridge._on_usb)

--- a/src/plugins/home_assistant_mqtt_pub/mqtt_config_panel.py
+++ b/src/plugins/home_assistant_mqtt_pub/mqtt_config_panel.py
@@ -99,6 +99,7 @@ class MqttConfigPanel(ConfigPanel):
 
         self._entity_settings = EntitySettings(self._user_settings)
         self._sampler = SamplerRunner()
+        self._sample_tokens: list = []
         self.entity_rows: dict[str, _EntityRow] = {}
 
         entities_box = QGroupBox("Entities", self)
@@ -175,12 +176,22 @@ class MqttConfigPanel(ConfigPanel):
         return True
 
     def _sample_into_row(self, row: _EntityRow) -> None:
-        self._sampler.submit(row.entity.sample, lambda result: row.sample_arrived.emit(result))
+        token = self._sampler.submit(row.entity.sample, lambda result: row.sample_arrived.emit(result))
+        self._sample_tokens.append(token)
 
     def _refresh_all(self) -> None:
         for row in self.entity_rows.values():
             row.value_label.setText("Loading…")
             self._sample_into_row(row)
+
+    def cleanup(self) -> None:
+        # Called by ConfigurationDialog when the dialog is closing, before
+        # widgets get torn down. Cancel pending samples so the SamplerRunner
+        # skips their `on_done` (which would otherwise emit on row widgets
+        # destroyed seconds later by Qt's parent-child cascade).
+        for token in self._sample_tokens:
+            token.cancel()
+        self._sample_tokens.clear()
 
     def _on_forget_device(self) -> None:
         confirm = QMessageBox.question(

--- a/src/plugins/home_assistant_mqtt_pub/publisher.py
+++ b/src/plugins/home_assistant_mqtt_pub/publisher.py
@@ -77,6 +77,7 @@ class Publisher:
         self._entities = list(entities)
         self._commands = list(commands)
         self._timers: dict[str, QTimer] = {}
+        self._sample_tokens: list = []
 
     def _enabled_entities(self) -> list:
         return [e for e in self._entities
@@ -137,7 +138,8 @@ class Publisher:
         self._restart_timers()
 
     def tick(self, entity) -> None:
-        self._sampler.submit(entity.sample, lambda result: self._publish_state(entity, result))
+        token = self._sampler.submit(entity.sample, lambda result: self._publish_state(entity, result))
+        self._sample_tokens.append(token)
 
     def _publish_state(self, entity, result: SampleResult) -> None:
         if not result.is_available:
@@ -171,6 +173,9 @@ class Publisher:
         for timer in self._timers.values():
             timer.stop()
         self._timers.clear()
+        for token in self._sample_tokens:
+            token.cancel()
+        self._sample_tokens.clear()
         for entity in self._entities:
             if entity.is_event_driven:
                 try:

--- a/src/plugins/home_assistant_mqtt_pub/sampler_runner.py
+++ b/src/plugins/home_assistant_mqtt_pub/sampler_runner.py
@@ -4,6 +4,8 @@ import threading
 from collections.abc import Callable
 from typing import Any
 
+from ...base.cancellation import Token
+
 
 class SamplerRunner:
     """Single-thread queue for sampling work that can't sit on the Qt thread.
@@ -18,16 +20,23 @@ class SamplerRunner:
             target=self._run, daemon=True, name="HASamplerRunner")
         self._thread.start()
 
-    def submit(self, fn: Callable[[], Any], on_done: Callable[[Any], None]) -> None:
-        self._queue.put((fn, on_done))
+    def submit(self, fn: Callable[[], Any], on_done: Callable[[Any], None]) -> Token:
+        """Submit a sample; returns a token that suppresses `on_done` when
+        cancelled. `fn` itself may still run (it has no side effects on Qt
+        objects); only the delivery callback is gated by the token."""
+        token = Token()
+        self._queue.put((fn, on_done, token))
+        return token
 
     def _run(self) -> None:
         while True:
-            fn, on_done = self._queue.get()
+            fn, on_done, token = self._queue.get()
             try:
                 value = fn()
             except Exception:
                 logging.exception("HA sampler fn raised")
+                continue
+            if token.is_cancelled:
                 continue
             try:
                 on_done(value)

--- a/src/swiss_windows_knife.py
+++ b/src/swiss_windows_knife.py
@@ -1,3 +1,4 @@
+import ctypes
 import inspect
 import logging
 import signal
@@ -7,7 +8,25 @@ import traceback
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QApplication
 
+from src.app_info import APP_INFO
 from src.ui.tray_widget import TrayWidget
+
+
+def _set_windows_app_user_model_id() -> None:
+    """Tell Windows this process is its own app, not Python.
+
+    Without this, the Windows taskbar groups by the host `python.exe` (in
+    dev runs) or by the frozen exe path (in cx_Freeze builds), and shows
+    Python's icon and "python" title rather than ours. Setting an
+    explicit AppUserModelID makes Windows use the QApplication icon and
+    window titles instead. No-op on non-Windows.
+    """
+    try:
+        ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
+            f"com.dbtdsilva.{APP_INFO.APP_NAME}".lower().replace(" ", "-"),
+        )
+    except (AttributeError, OSError):
+        pass
 
 
 class SwissWindowsKnife:
@@ -16,7 +35,9 @@ class SwissWindowsKnife:
         self.init_logging()
 
         signal.signal(signal.SIGINT, signal.SIG_DFL)
+        _set_windows_app_user_model_id()
         app = QApplication(sys.argv)
+        app.setApplicationName(APP_INFO.APP_NAME)
         app.setQuitOnLastWindowClosed(False)
         app.setWindowIcon(QIcon(":/icons/coat-of-arms.ico"))
 

--- a/src/ui/about_dialog.py
+++ b/src/ui/about_dialog.py
@@ -1,7 +1,6 @@
 from PySide6.QtCore import Qt
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import (
-    QDialog,
     QDialogButtonBox,
     QLabel,
     QVBoxLayout,
@@ -9,9 +8,13 @@ from PySide6.QtWidgets import (
 )
 
 from ..app_info import APP_INFO
+from ..base.persistent_dialog import PersistentSizeDialog
 
 
-class AboutDialog(QDialog):
+class AboutDialog(PersistentSizeDialog):
+
+    size_settings_prefix = "about_dialog"
+
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self.setWindowTitle(f'About {APP_INFO.APP_NAME}')
@@ -44,3 +47,6 @@ class AboutDialog(QDialog):
         layout.addWidget(icon_label)
         layout.addWidget(info_label)
         layout.addWidget(button_box)
+
+        self.adjustSize()
+        self.restore_size(self.size())

--- a/src/ui/configuration_dialog.py
+++ b/src/ui/configuration_dialog.py
@@ -59,3 +59,16 @@ class ConfigurationDialog(PersistentSizeDialog):
             if not panel.apply():
                 return
         self.accept()
+
+    def done(self, result: int) -> None:
+        # Fires on OK (`accept()`), Cancel (`reject()`), and X (`closeEvent`
+        # → default `done(Rejected)`). Run panel cleanup *before* Qt starts
+        # destroying anything so panels can cancel in-flight async work
+        # while their child widgets are still alive.
+        for panel in self._panels:
+            try:
+                panel.cleanup()
+            except Exception:
+                import logging
+                logging.exception("ConfigPanel.cleanup raised")
+        super().done(result)

--- a/src/ui/tray_widget.py
+++ b/src/ui/tray_widget.py
@@ -29,7 +29,11 @@ class TrayWidget(QWidget):
 
         self._config_dialog: ConfigurationDialog | None = None
 
-        self.logger_window = TrayLogger(self)
+        # Dialogs use `parent=None` so Windows treats them as top-level
+        # owned-by-nothing — required for them to get their own taskbar
+        # entry and the app icon. With a parent, the OS treats them as
+        # owned by the (hidden) TrayWidget and hides them from the taskbar.
+        self.logger_window = TrayLogger(None)
         self.logger_window.hide()
 
         self.child_components: list[BaseWidget] = [
@@ -122,7 +126,7 @@ class TrayWidget(QWidget):
         if not panels:
             logging.info("No plugin contributes a configuration panel")
             return
-        self._config_dialog = ConfigurationDialog(self, panels)
+        self._config_dialog = ConfigurationDialog(None, panels)
         try:
             self._config_dialog.exec()
         finally:
@@ -143,4 +147,4 @@ class TrayWidget(QWidget):
 
     @Slot()
     def open_about_dialog(self) -> None:
-        AboutDialog(self).exec()
+        AboutDialog(None).exec()

--- a/tests/test_display_automation_panel.py
+++ b/tests/test_display_automation_panel.py
@@ -42,3 +42,41 @@ def test_panel_with_no_monitors_or_devices_apply_is_noop(make_panel, fake_user_s
     assert panel.apply() is True
     # No settings should be written when there is nothing to choose from.
     assert fake_user_settings.get('display_usb_watcher') is None
+
+
+def test_panel_renders_usb_devices_and_persists_selection(make_panel, fake_user_settings):
+    devices = [
+        _FakeDevice(id="USB\\VID_1234&PID_5678\\AAA", name="Dock A", description="USB-C dock"),
+        _FakeDevice(id="USB\\VID_9999&PID_1111\\BBB", name="Mouse", description="Optical mouse"),
+    ]
+    panel = make_panel(monitors=[], usb_devices=devices)
+
+    assert panel._usb_combo is not None
+    # First entry is the "(none)" option, then one entry per device, in input order.
+    assert panel._usb_combo.count() == 1 + len(devices)
+
+    panel._usb_combo.setCurrentIndex(2)  # Select "Mouse"
+    assert panel.apply() is True
+    assert fake_user_settings.get('display_usb_watcher') == "USB\\VID_9999&PID_1111\\BBB"
+
+
+def test_panel_preselects_existing_usb_watcher(make_panel, fake_user_settings):
+    fake_user_settings.set('display_usb_watcher', "USB\\VID_1234&PID_5678\\AAA")
+    devices = [
+        _FakeDevice(id="USB\\VID_1234&PID_5678\\AAA", name="Dock A"),
+        _FakeDevice(id="USB\\VID_9999&PID_1111\\BBB", name="Mouse"),
+    ]
+    panel = make_panel(monitors=[], usb_devices=devices)
+
+    # Index 1 is the first device in our list; 0 is the "(none)" sentinel.
+    assert panel._usb_combo.currentIndex() == 1
+
+
+def test_panel_apply_with_none_clears_usb_watcher(make_panel, fake_user_settings):
+    fake_user_settings.set('display_usb_watcher', "USB\\VID_1234&PID_5678\\AAA")
+    devices = [_FakeDevice(id="USB\\VID_1234&PID_5678\\AAA", name="Dock A")]
+    panel = make_panel(monitors=[], usb_devices=devices)
+    panel._usb_combo.setCurrentIndex(0)  # "(none)"
+
+    assert panel.apply() is True
+    assert fake_user_settings.get('display_usb_watcher') is None

--- a/tests/test_display_automation_panel.py
+++ b/tests/test_display_automation_panel.py
@@ -1,0 +1,44 @@
+import pytest
+
+
+class _FakeMonitorInfo:
+    def __init__(self, device_id, device_name, model, inputs):
+        self.device_id = device_id
+        self.device_name = device_name
+        self.model = model
+        self.inputs = inputs
+
+
+class _FakeDevice:
+    def __init__(self, id, name, description="", manufacturer=""):
+        self.id = id
+        self.name = name
+        self.description = description
+        self.manufacturer = manufacturer
+
+
+@pytest.fixture
+def make_panel(qtbot, fake_user_settings, silent_messagebox):
+    """Build a panel with controllable, sync providers."""
+    from src.plugins.device_display_mapper.display_automation_panel import (
+        DisplayAutomationConfigPanel,
+    )
+
+    def _make(monitors=None, usb_devices=None):
+        panel = DisplayAutomationConfigPanel(
+            parent=None,
+            list_monitors=lambda: list(monitors or []),
+            list_usb_devices=lambda: list(usb_devices or []),
+            schedule_discovery=lambda fn: fn(),  # run inline for tests
+        )
+        qtbot.addWidget(panel)
+        return panel
+
+    return _make
+
+
+def test_panel_with_no_monitors_or_devices_apply_is_noop(make_panel, fake_user_settings):
+    panel = make_panel(monitors=[], usb_devices=[])
+    assert panel.apply() is True
+    # No settings should be written when there is nothing to choose from.
+    assert fake_user_settings.get('display_usb_watcher') is None

--- a/tests/test_display_automation_panel.py
+++ b/tests/test_display_automation_panel.py
@@ -80,3 +80,57 @@ def test_panel_apply_with_none_clears_usb_watcher(make_panel, fake_user_settings
 
     assert panel.apply() is True
     assert fake_user_settings.get('display_usb_watcher') is None
+
+
+def test_panel_renders_per_monitor_input_choices_and_persists(make_panel, fake_user_settings):
+    monitors = [
+        _FakeMonitorInfo(
+            device_id="MON-A-DEVID",
+            device_name="\\\\.\\DISPLAY1",
+            model="Dell U2723QE",
+            inputs=["DP1", "HDMI1", "USBC"],
+        ),
+        _FakeMonitorInfo(
+            device_id="MON-B-DEVID",
+            device_name="\\\\.\\DISPLAY2",
+            model="LG 27UP850",
+            inputs=["DP1", "HDMI2"],
+        ),
+    ]
+    panel = make_panel(monitors=monitors, usb_devices=[])
+
+    assert "MON-A-DEVID" in panel._monitor_groups
+    assert "MON-B-DEVID" in panel._monitor_groups
+
+    a = panel._monitor_groups["MON-A-DEVID"]
+    # Each combobox has the inputs plus a "(unchanged)" sentinel at index 0.
+    assert a["connect_combo"].count() == 1 + 3
+    assert a["disconnect_combo"].count() == 1 + 3
+
+    a["connect_combo"].setCurrentIndex(2)     # "HDMI1" on connect
+    a["disconnect_combo"].setCurrentIndex(1)  # "DP1" on disconnect
+
+    assert panel.apply() is True
+    assert fake_user_settings.get('display_on_connect_MON-A-DEVID') == "HDMI1"
+    assert fake_user_settings.get('display_on_disconnect_MON-A-DEVID') == "DP1"
+    # Untouched monitor keeps its "(unchanged)" sentinel — no key written.
+    assert fake_user_settings.get('display_on_connect_MON-B-DEVID') is None
+
+
+def test_panel_preselects_existing_per_monitor_choice(make_panel, fake_user_settings):
+    fake_user_settings.set('display_on_connect_MON-A-DEVID', "HDMI1")
+    fake_user_settings.set('display_on_disconnect_MON-A-DEVID', "DP1")
+    monitors = [
+        _FakeMonitorInfo(
+            device_id="MON-A-DEVID",
+            device_name="\\\\.\\DISPLAY1",
+            model="Dell U2723QE",
+            inputs=["DP1", "HDMI1", "USBC"],
+        ),
+    ]
+    panel = make_panel(monitors=monitors, usb_devices=[])
+
+    a = panel._monitor_groups["MON-A-DEVID"]
+    # "HDMI1" is index 2 (after the "(unchanged)" sentinel + "DP1" at index 1).
+    assert a["connect_combo"].currentText() == "HDMI1"
+    assert a["disconnect_combo"].currentText() == "DP1"

--- a/tests/test_display_automation_panel.py
+++ b/tests/test_display_automation_panel.py
@@ -117,6 +117,33 @@ def test_panel_renders_per_monitor_input_choices_and_persists(make_panel, fake_u
     assert fake_user_settings.get('display_on_connect_MON-B-DEVID') is None
 
 
+def test_panel_populates_when_discovery_completes_async(qtbot, fake_user_settings, silent_messagebox):
+    """When schedule_discovery defers `_populate`, the panel still shows the
+    placeholder before discovery and the widgets after."""
+    from src.plugins.device_display_mapper.display_automation_panel import (
+        DisplayAutomationConfigPanel,
+    )
+    deferred: list = []
+
+    panel = DisplayAutomationConfigPanel(
+        parent=None,
+        list_monitors=lambda: [],
+        list_usb_devices=lambda: [_FakeDevice(id="X", name="X")],
+        schedule_discovery=lambda fn: deferred.append(fn),
+    )
+    qtbot.addWidget(panel)
+
+    assert panel._placeholder.isHidden() is False  # placeholder visible
+    assert panel._usb_combo is None  # not yet populated
+
+    # Simulate async completion.
+    for fn in deferred:
+        fn()
+
+    assert panel._placeholder.isHidden() is True
+    assert panel._usb_combo is not None
+
+
 def test_panel_preselects_existing_per_monitor_choice(make_panel, fake_user_settings):
     fake_user_settings.set('display_on_connect_MON-A-DEVID', "HDMI1")
     fake_user_settings.set('display_on_disconnect_MON-A-DEVID', "DP1")

--- a/tests/test_monitor_runner.py
+++ b/tests/test_monitor_runner.py
@@ -56,3 +56,39 @@ def test_runner_passes_args_and_kwargs():
 
     assert done.wait(timeout=2.0)
     assert captured == [((1, 2), {"foo": "bar"})]
+
+
+def test_runner_skips_cancelled_tasks():
+    runner = _MonitorRunner()
+
+    call_log: list[str] = []
+    drained = threading.Event()
+
+    def slow_task(name: str) -> None:
+        # Hold the worker so we can cancel later submissions before they run.
+        threading.Event().wait(0.05)
+        call_log.append(name)
+
+    def sentinel() -> None:
+        call_log.append("sentinel")
+        drained.set()
+
+    # First task occupies the worker; cancel the second; third should still run.
+    runner.submit(slow_task, "first")
+    cancel_me = runner.submit(slow_task, "should-not-run")
+    cancel_me.cancel()
+    runner.submit(sentinel)
+
+    assert drained.wait(timeout=2.0), "runner did not reach sentinel"
+    assert call_log == ["first", "sentinel"]
+
+
+def test_runner_submit_returns_token_for_each_call():
+    runner = _MonitorRunner()
+    t1 = runner.submit(lambda: None)
+    t2 = runner.submit(lambda: None)
+    assert t1 is not t2
+    assert not t1.is_cancelled
+    t1.cancel()
+    assert t1.is_cancelled
+    assert not t2.is_cancelled


### PR DESCRIPTION
## Summary
- Pulls the per-monitor "Display automation" submenu out of the tray menu and into a new `DisplayAutomationConfigPanel` shown in the unified Configuration dialog. Tray icon now appears in ~200 ms instead of waiting on synchronous DDC/CI capability reads + a full `Win32_PnPEntity` enumeration.
- Discovery work runs off the GUI thread: monitor capabilities via the existing `runner()`, USB enumeration on a one-shot `QThread` worker (with its own `pythoncom.CoInitialize`). Both caches are pre-warmed at plugin init so the first time the user opens Configuration the panel populates instantly.
- Async work is gated by a new `Token` cancellation primitive plumbed through `_MonitorRunner`, `SamplerRunner`, and the plugin's USB callback queue. Panels cancel their tokens via a `ConfigPanel.cleanup()` hook called by `ConfigurationDialog.done()` before Qt tears widgets down — replacing the old "swallow `RuntimeError` from late emits" workaround that produced noisy logs on every dialog close.
- Existing settings keys (`display_usb_watcher`, `display_on_connect_<id>`, `display_on_disconnect_<id>`) are unchanged so prior configuration carries over with no migration. The runtime hot-path (`device_changed` → `_apply_input_source`) is untouched.
- Dialogs (Configuration, About, View Logs) now appear in the Windows taskbar with the Swiss Windows Knife icon and title — fixed via `Qt.Window` flags, parent-less construction, and an explicit \`AppUserModelID\`. AboutDialog also gained persistent size.

Plan: \`docs/superpowers/plans/2026-04-30-display-automation-config-panel.md\`.

## Test plan
- [x] \`pytest tests/\` — 167 passed (7 new panel tests + 2 token-cancellation tests).
- [x] \`ruff check src/ tests/\` — clean.
- [x] Cold launch: tray icon appears in ~200 ms; logs show no DDC/CI capability reads or PnP enumeration on the GUI thread.
- [x] Cycle Configuration open/close several times: no \`RuntimeError: Signal source has been deleted\` in the logs.
- [x] First Configuration open after launch populates without a placeholder (caches prewarmed).
- [x] Configuration / About / View Logs each show their own taskbar entry with the app icon and the dialog's title.
- [x] Plug/unplug the configured USB device with new settings → input source still switches as before (runtime path unchanged).