### PR TITLE
fix: skip faulthandler.enable() in frozen Win32GUI builds

### DIFF
--- a/src/swiss_windows_knife.py
+++ b/src/swiss_windows_knife.py
@@ -34,7 +34,12 @@ class SwissWindowsKnife:
 
     def __init__(self, dev_mode: bool = False) -> None:
         self.init_logging()
-        faulthandler.enable()  # native crashes print a C-stack to stderr
+        # Native crashes print a C-stack to stderr — but cx_Freeze with
+        # `base='Win32GUI'` builds the frozen exe without a console, so
+        # `sys.stderr` is None and `faulthandler.enable()` raises
+        # `RuntimeError: sys.stderr is None`. Skip it in that case.
+        if sys.stderr is not None:
+            faulthandler.enable()
 
         signal.signal(signal.SIGINT, signal.SIG_DFL)
         _set_windows_app_user_model_id()


### PR DESCRIPTION
## Summary
- 1.15.0's exe fails to launch with \`RuntimeError: sys.stderr is None\` raised inside \`faulthandler.enable()\`. cx_Freeze's \`base='Win32GUI'\` builds without a console so \`sys.stderr\` is None at startup, and faulthandler refuses to attach to nothing.
- Guard the call: \`faulthandler.enable()\` only runs when \`sys.stderr is not None\` (i.e., dev runs). Frozen builds quietly skip it. Native crashes in production won't be captured but the app starts.

## Test plan
- [x] \`pytest tests/\` — 188 passed.
- [x] \`ruff check src/ tests/\` — clean.
- [x] Build via \`python setup.py exe\` and run the produced exe — confirm it launches without the faulthandler error.