### PR TITLE
feat: plugin health status in tray menu

### DIFF
--- a/.github/workflows/build-n-test.yml
+++ b/.github/workflows/build-n-test.yml
@@ -16,6 +16,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -e .[build,test]
+    - name: Generate Qt resources
+      run: python setup.py resources
     - name: Lint with ruff
       run: |
         pip install ruff

--- a/docs/superpowers/plans/2026-04-30-plugin-health-status.md
+++ b/docs/superpowers/plans/2026-04-30-plugin-health-status.md
@@ -1,0 +1,1325 @@
+# Plugin Health Status Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Surface per-plugin health in the tray menu — a worst-state summary line plus a `Health` submenu listing each plugin's state and short status message.
+
+**Architecture:** Each plugin owns a `_current_health: HealthReport` attribute that it updates eagerly from inside its existing event paths (paho callbacks, monitor-runner result handlers, QThread `finished` signals). `BaseWidget.health()` is a pure read; the tray pulls all reports on `aboutToShow` and aggregates worst-state. No new threads, no signals.
+
+**Tech Stack:** Python 3.12, PySide6, paho-mqtt, monitorcontrol, pytest-qt. Design doc: `docs/superpowers/specs/2026-04-30-plugin-health-status-design.md`.
+
+**Branch:** `feat/plugin-health-status` (already created; design doc already committed).
+
+**Commit style:** angular conventional commits. Whole feature ships as `feat:` (one minor bump). The internal `MqttSession.on_disconnected` hook lands in the same `feat:` series. Per-task commits are encouraged; squash-merge is fine.
+
+---
+
+### Task 1: Health types
+
+**Files:**
+- Create: `src/base/health.py`
+- Test: `tests/test_health_types.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_health_types.py`:
+
+```python
+import pytest
+
+from src.base.health import HealthReport, HealthState
+
+
+def test_health_state_has_four_values():
+    assert {s.value for s in HealthState} == {"ok", "warning", "error", "disabled"}
+
+
+def test_health_report_holds_state_and_message():
+    r = HealthReport(HealthState.OK, "Connected")
+    assert r.state is HealthState.OK
+    assert r.message == "Connected"
+
+
+def test_health_report_is_frozen():
+    r = HealthReport(HealthState.OK, "Connected")
+    with pytest.raises((AttributeError, Exception)):
+        r.message = "Other"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_health_types.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'src.base.health'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/base/health.py`:
+
+```python
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class HealthState(StrEnum):
+    OK = "ok"
+    WARNING = "warning"
+    ERROR = "error"
+    DISABLED = "disabled"
+
+
+@dataclass(frozen=True)
+class HealthReport:
+    state: HealthState
+    message: str
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_health_types.py -v`
+Expected: 3 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/base/health.py tests/test_health_types.py
+git commit -m "feat: add HealthState enum and HealthReport dataclass"
+```
+
+---
+
+### Task 2: BaseWidget health hook
+
+**Files:**
+- Modify: `src/base/base_widget.py`
+- Modify: `tests/test_base_widget.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_base_widget.py`:
+
+```python
+def test_health_defaults_to_ok_with_empty_message(qtbot, fake_user_settings):
+    from src.base.health import HealthReport, HealthState
+    widget = BaseWidget(None)
+    qtbot.addWidget(widget)
+    assert widget.health() == HealthReport(HealthState.OK, "")
+
+
+def test_set_health_updates_current_health(qtbot, fake_user_settings):
+    from src.base.health import HealthReport, HealthState
+    widget = BaseWidget(None)
+    qtbot.addWidget(widget)
+    widget._set_health(HealthState.WARNING, "broker down")
+    assert widget.health() == HealthReport(HealthState.WARNING, "broker down")
+
+
+def test_health_returns_disabled_for_toggleable_off(qtbot, fake_user_settings):
+    from src.base.health import HealthReport, HealthState
+    widget = BaseWidget(None, is_toggleable=True, is_enabled=False)
+    qtbot.addWidget(widget)
+    widget._set_health(HealthState.WARNING, "ignored while off")
+    assert widget.health() == HealthReport(HealthState.DISABLED, "")
+
+
+def test_health_ignores_is_enabled_for_non_toggleable_widget(qtbot, fake_user_settings):
+    from src.base.health import HealthReport, HealthState
+    widget = BaseWidget(None, is_toggleable=False, is_enabled=False)
+    qtbot.addWidget(widget)
+    widget._set_health(HealthState.OK, "running")
+    assert widget.health() == HealthReport(HealthState.OK, "running")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_base_widget.py -v`
+Expected: 4 new tests FAIL — `AttributeError: 'BaseWidget' object has no attribute 'health'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `src/base/base_widget.py`. Add an import at the top:
+
+```python
+from .health import HealthReport, HealthState
+```
+
+In `BaseWidget.__init__`, after the existing `self._is_enabled = …` block, add:
+
+```python
+        self._current_health: HealthReport = HealthReport(HealthState.OK, "")
+```
+
+Add two new methods at the end of the class:
+
+```python
+    def health(self) -> HealthReport:
+        """Return the plugin's current health snapshot.
+
+        MUST be cheap and non-blocking — no I/O, no DDC calls, no socket
+        reads. Subclasses do not override this; instead they call
+        `_set_health` from inside whatever event path changed their state.
+        """
+        if self._is_toggleable and not self._is_enabled:
+            return HealthReport(HealthState.DISABLED, "")
+        return self._current_health
+
+    def _set_health(self, state: HealthState, message: str) -> None:
+        self._current_health = HealthReport(state, message)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_base_widget.py -v`
+Expected: All tests PASS (existing + 4 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/base/base_widget.py tests/test_base_widget.py
+git commit -m "feat: BaseWidget exposes health() with disabled short-circuit"
+```
+
+---
+
+### Task 3: MqttSession on_disconnected hook
+
+**Files:**
+- Modify: `src/plugins/home_assistant_mqtt_pub/mqtt_session.py`
+- Modify: `tests/test_ha_session.py`
+- Modify: `tests/conftest.py` (add `fire_on_disconnect` to `_FakePahoClient`)
+
+- [ ] **Step 1: Add a `fire_on_disconnect` helper to the existing fake**
+
+Edit `tests/conftest.py`. Add after the existing `fire_on_message` method on `_FakePahoClient`:
+
+```python
+    def fire_on_disconnect(self, rc=0):
+        self.connected = False
+        if self.on_disconnect is not None:
+            self.on_disconnect(self, None, None, rc, None)
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Append to `tests/test_ha_session.py`:
+
+```python
+def test_on_disconnect_fires_callback(fake_paho_client):
+    sess = MqttSession(broker_config=_broker(), availability_topic=_ctx().availability_topic)
+    fired: list[bool] = []
+    sess.on_disconnected = lambda: fired.append(True)
+    sess.start()
+    fake_paho_client[0].fire_on_connect(rc=0)
+    fake_paho_client[0].fire_on_disconnect(rc=0)
+    assert fired == [True]
+
+
+def test_on_disconnect_callback_exceptions_are_swallowed(fake_paho_client):
+    sess = MqttSession(broker_config=_broker(), availability_topic=_ctx().availability_topic)
+
+    def boom():
+        raise RuntimeError("ignored")
+
+    sess.on_disconnected = boom
+    sess.start()
+    fake_paho_client[0].fire_on_disconnect(rc=0)  # must not raise
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_ha_session.py -v -k disconnect`
+Expected: 2 tests FAIL — `AttributeError: 'MqttSession' object has no attribute 'on_disconnected'`.
+
+- [ ] **Step 4: Write minimal implementation**
+
+Modify `src/plugins/home_assistant_mqtt_pub/mqtt_session.py`:
+
+In `__init__`, after the existing `self.on_connected = None` line, add:
+
+```python
+        self.on_disconnected: Callable[[], None] | None = None
+```
+
+Replace `_on_disconnect` with:
+
+```python
+    def _on_disconnect(self, client, userdata, flags, rc, properties):
+        logging.info("MQTT disconnected rc=%s", rc)
+        if self.on_disconnected is not None:
+            try:
+                self.on_disconnected()
+            except Exception:
+                logging.exception("on_disconnected hook raised")
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_ha_session.py -v`
+Expected: All tests PASS (existing + 2 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/plugins/home_assistant_mqtt_pub/mqtt_session.py tests/test_ha_session.py tests/conftest.py
+git commit -m "feat: MqttSession exposes on_disconnected hook"
+```
+
+---
+
+### Task 4: HomeAssistantMqttPubPlugin health wiring
+
+**Files:**
+- Modify: `src/plugins/home_assistant_mqtt_pub/home_assistant_mqtt_pub_plugin.py`
+- Create: `tests/test_ha_plugin_health.py`
+
+This task also removes the now-redundant `Home Assistant → Configured / Not configured` submenu from `retrieve_menus()` (the unified Health view replaces it).
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_ha_plugin_health.py`:
+
+```python
+import pytest
+
+from src.base.health import HealthState
+
+
+@pytest.fixture
+def configured_settings(fake_user_settings):
+    fake_user_settings.set("homeassistant_host", "broker")
+    fake_user_settings.set("homeassistant_port", 1883)
+    fake_user_settings.set("homeassistant_username", "u")
+    fake_user_settings.set("homeassistant_password", "p")
+    fake_user_settings.set("homeassistant_client_id", "cid")
+    fake_user_settings.set("homeassistant_device_name", "TestPC")
+    return fake_user_settings
+
+
+def _make_plugin(qtbot):
+    from src.plugins.home_assistant_mqtt_pub.home_assistant_mqtt_pub_plugin import (
+        HomeAssistantMqttPubPlugin,
+    )
+    plugin = HomeAssistantMqttPubPlugin(parent=None)
+    qtbot.addWidget(plugin)
+    return plugin
+
+
+def test_health_is_warning_not_configured_when_no_config(qtbot, fake_user_settings, fake_paho_client):
+    plugin = _make_plugin(qtbot)
+    report = plugin.health()
+    assert report.state is HealthState.WARNING
+    assert report.message == "Not configured"
+
+
+def test_health_is_warning_connecting_after_session_starts(qtbot, configured_settings, fake_paho_client):
+    plugin = _make_plugin(qtbot)
+    report = plugin.health()
+    assert report.state is HealthState.WARNING
+    assert report.message == "Connecting…"
+
+
+def test_health_is_ok_connected_after_on_connect(qtbot, configured_settings, fake_paho_client):
+    plugin = _make_plugin(qtbot)
+    fake_paho_client[0].fire_on_connect(rc=0)
+    report = plugin.health()
+    assert report.state is HealthState.OK
+    assert report.message == "Connected"
+
+
+def test_health_returns_to_warning_after_disconnect(qtbot, configured_settings, fake_paho_client):
+    plugin = _make_plugin(qtbot)
+    fake_paho_client[0].fire_on_connect(rc=0)
+    fake_paho_client[0].fire_on_disconnect(rc=0)
+    qtbot.wait(20)  # cross to GUI thread via QMetaObject.invokeMethod
+    report = plugin.health()
+    assert report.state is HealthState.WARNING
+    assert report.message == "Disconnected"
+
+
+def test_retrieve_menus_no_longer_returns_status_submenu(qtbot, configured_settings, fake_paho_client):
+    plugin = _make_plugin(qtbot)
+    assert plugin.retrieve_menus() == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_ha_plugin_health.py -v`
+Expected: 5 tests FAIL — health is OK with empty message (default), and `retrieve_menus()` still returns the legacy submenu.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `src/plugins/home_assistant_mqtt_pub/home_assistant_mqtt_pub_plugin.py`.
+
+Add imports near the top, with the other base imports:
+
+```python
+from ...base.health import HealthState
+```
+
+In `__init__`, replace the section starting at the `cfg = MqttConfig.load_from_settings(...)` line with:
+
+```python
+        cfg = MqttConfig.load_from_settings(self._user_settings)
+        self.is_homeassistant_configured = cfg.is_complete()
+        if self.is_homeassistant_configured:
+            self._set_health(HealthState.WARNING, "Connecting…")
+            self._start_session(cfg)
+        else:
+            self._set_health(HealthState.WARNING, "Not configured")
+```
+
+In `_start_session`, after `self._session.on_connected = self._dispatch_on_connected`, add:
+
+```python
+        self._session.on_disconnected = self._dispatch_on_disconnected
+```
+
+Add a new dispatcher and slot, mirroring `_dispatch_on_connected` / `_run_on_connected`:
+
+```python
+    def _dispatch_on_disconnected(self) -> None:
+        QMetaObject.invokeMethod(self, "_run_on_disconnected", Qt.ConnectionType.QueuedConnection)
+
+    @Slot()
+    def _run_on_disconnected(self) -> None:
+        self._set_health(HealthState.WARNING, "Disconnected")
+```
+
+In `_run_on_connected`, prepend `self._set_health(HealthState.OK, "Connected")`:
+
+```python
+    @Slot()
+    def _run_on_connected(self) -> None:
+        self._set_health(HealthState.OK, "Connected")
+        if self._publisher is not None:
+            self._publisher.on_connected()
+```
+
+In `status_changed`, ensure the message reflects the new state. Replace the method with:
+
+```python
+    @override
+    def status_changed(self, status: bool) -> None:
+        if status and self._session is None and self.is_homeassistant_configured:
+            cfg = MqttConfig.load_from_settings(self._user_settings)
+            self._set_health(HealthState.WARNING, "Connecting…")
+            self._start_session(cfg)
+        elif not status and self._publisher is not None and self._session is not None:
+            try:
+                self._publisher.delete_all_for_current_device()
+            finally:
+                self._publisher.stop()
+                self._session.stop()
+                self._publisher = None
+                self._session = None
+```
+
+(No health update inside the `not status` branch — `BaseWidget.health()` handles `Disabled` via the toggle short-circuit.)
+
+In `reload_session`, after `self.is_homeassistant_configured = cfg.is_complete()`, replace the trailing `if`-block with:
+
+```python
+        if self.is_homeassistant_configured and self.is_enabled():
+            self._set_health(HealthState.WARNING, "Connecting…")
+            self._start_session(cfg)
+        elif not self.is_homeassistant_configured:
+            self._set_health(HealthState.WARNING, "Not configured")
+```
+
+Replace `retrieve_menus`:
+
+```python
+    @override
+    def retrieve_menus(self) -> list[QMenu | QAction]:
+        return []
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_ha_plugin_health.py tests/test_ha_plugin.py -v`
+Expected: All HA-plugin tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plugins/home_assistant_mqtt_pub/home_assistant_mqtt_pub_plugin.py tests/test_ha_plugin_health.py
+git commit -m "feat: home-assistant plugin reports health and drops status submenu"
+```
+
+---
+
+### Task 5: DisplayImageTunerPlugin health wiring
+
+**Files:**
+- Modify: `src/plugins/display_image_tuner/image_tuner_plugin.py`
+- Create: `tests/test_display_image_tuner_health.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_display_image_tuner_health.py`:
+
+```python
+from unittest.mock import MagicMock, patch
+
+import monitorcontrol
+import pytest
+
+from src.base.health import HealthState
+
+
+@pytest.fixture
+def plugin(qtbot, fake_user_settings):
+    from src.plugins.display_image_tuner.image_tuner_plugin import DisplayImageTunerPlugin
+    p = DisplayImageTunerPlugin(None)
+    qtbot.addWidget(p)
+    return p
+
+
+def test_initial_health_is_ok_auto(plugin):
+    report = plugin.health()
+    assert report.state is HealthState.OK
+    assert report.message == "Auto"
+
+
+def test_health_message_reflects_manual_brightness(qtbot, fake_user_settings):
+    fake_user_settings.set("brightness", 60)
+    from src.plugins.display_image_tuner.image_tuner_plugin import DisplayImageTunerPlugin
+    p = DisplayImageTunerPlugin(None)
+    qtbot.addWidget(p)
+    assert p.health().message == "Manual 60"
+
+
+def _stub_monitor(value: int):
+    cm = MagicMock()
+    cm.__enter__ = lambda self: self
+    cm.__exit__ = lambda self, exc_type, exc, tb: None
+    cm.get_luminance = MagicMock(return_value=value)
+    cm.set_luminance = MagicMock()
+    cm.get_contrast = MagicMock(return_value=value)
+    cm.set_contrast = MagicMock()
+    return cm
+
+
+def test_apply_brightness_failure_sets_warning(plugin):
+    with patch("monitorcontrol.get_monitors", side_effect=monitorcontrol.VCPError("boom")):
+        plugin._apply_brightness(50)
+    assert plugin.health().state is HealthState.WARNING
+    assert "Monitor error" in plugin.health().message
+
+
+def test_apply_brightness_success_restores_ok(plugin):
+    with patch("monitorcontrol.get_monitors", side_effect=monitorcontrol.VCPError("boom")):
+        plugin._apply_brightness(50)
+    assert plugin.health().state is HealthState.WARNING
+
+    with patch("monitorcontrol.get_monitors", return_value=[_stub_monitor(0)]):
+        plugin._apply_brightness(50)
+    assert plugin.health().state is HealthState.OK
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_display_image_tuner_health.py -v`
+Expected: 4 tests FAIL — initial message is empty, `_apply_brightness` does not touch health.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `src/plugins/display_image_tuner/image_tuner_plugin.py`.
+
+Add import near the other base imports:
+
+```python
+from ...base.health import HealthState
+```
+
+In `DisplayImageTunerPlugin.__init__`, after the existing `self.contrast_changed.connect(...)` line and before the `_tick_timer` block, add:
+
+```python
+        self._set_health(HealthState.OK, self._mode_message())
+```
+
+Add a helper method on the class (anywhere; place it next to `_seed_default_settings`):
+
+```python
+    def _mode_message(self) -> str:
+        b = self.user_settings.get('brightness')
+        if b is None:
+            return "Auto"
+        return f"Manual {b}"
+```
+
+In `_apply_brightness`, replace the body with:
+
+```python
+    def _apply_brightness(self, brightness):
+        try:
+            for i, monitor in enumerate(monitorcontrol.get_monitors()):
+                with monitor:
+                    if monitor.get_luminance() != brightness:
+                        monitor.set_luminance(brightness)
+                        logging.info(f"Setting brightness to {brightness} on monitor {i}")
+            self._set_health(HealthState.OK, self._mode_message())
+        except (ValueError, monitorcontrol.VCPError) as e:
+            logging.warning(f"Exception was caught while changing brightness: {e}")
+            self._set_health(HealthState.WARNING, f"Monitor error: {e}")
+```
+
+Mirror the same change in `_apply_contrast`:
+
+```python
+    def _apply_contrast(self, contrast):
+        try:
+            for i, monitor in enumerate(monitorcontrol.get_monitors()):
+                with monitor:
+                    if monitor.get_contrast() != contrast:
+                        monitor.set_contrast(contrast)
+                        logging.info(f"Setting contrast to {contrast} on monitor {i}")
+            self._set_health(HealthState.OK, self._mode_message())
+        except (ValueError, monitorcontrol.VCPError) as e:
+            logging.warning(f"Exception was caught while changing contrast: {e}")
+            self._set_health(HealthState.WARNING, f"Monitor error: {e}")
+```
+
+In `change_brightness_manual`, after the `self.user_settings.set('brightness', brightness_level)` line, add:
+
+```python
+        if self._current_health.state is HealthState.OK:
+            self._set_health(HealthState.OK, self._mode_message())
+```
+
+Same in `change_contrast_manual` after `self.user_settings.set('contrast', contrast_level)`:
+
+```python
+        if self._current_health.state is HealthState.OK:
+            self._set_health(HealthState.OK, self._mode_message())
+```
+
+In `change_brightness_automatic`, after `self.user_settings.set('brightness', None)`:
+
+```python
+        if self._current_health.state is HealthState.OK:
+            self._set_health(HealthState.OK, self._mode_message())
+```
+
+Same in `change_contrast_automatic` after `self.user_settings.set('contrast', None)`:
+
+```python
+        if self._current_health.state is HealthState.OK:
+            self._set_health(HealthState.OK, self._mode_message())
+```
+
+(The `if state is OK` guard preserves an outstanding Warning until the next successful apply replaces it.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_display_image_tuner_health.py tests/test_display_image_tuner_plugin.py -v`
+Expected: All display-image-tuner tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plugins/display_image_tuner/image_tuner_plugin.py tests/test_display_image_tuner_health.py
+git commit -m "feat: display brightness plugin reports health"
+```
+
+---
+
+### Task 6: DeviceDisplayMapperPlugin health wiring
+
+**Files:**
+- Modify: `src/plugins/device_display_mapper/device_display_mapper_plugin.py`
+- Create: `tests/test_device_display_mapper_health.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_device_display_mapper_health.py`:
+
+```python
+import pytest
+
+from src.base.health import HealthState
+
+
+class _FakeDeviceListener:
+    instances: list = []
+
+    def __init__(self, parent):
+        self.closed = False
+
+        class _Sig:
+            def connect(self, *_args, **_kwargs):
+                pass
+
+        self.change_detected = _Sig()
+        _FakeDeviceListener.instances.append(self)
+
+    def close(self):
+        self.closed = True
+
+
+class _ExplodingListener:
+    def __init__(self, parent):
+        raise RuntimeError("WMI unavailable")
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    _FakeDeviceListener.instances.clear()
+    yield
+    _FakeDeviceListener.instances.clear()
+
+
+def _patch(monkeypatch, listener_cls):
+    monkeypatch.setattr(
+        "src.plugins.device_display_mapper.device_display_mapper_plugin.DeviceListener",
+        listener_cls,
+    )
+    monkeypatch.setattr(
+        "src.plugins.device_display_mapper.device_display_mapper_plugin."
+        "DeviceDisplayMapperPlugin._prewarm_monitor_cache",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        "src.plugins.device_display_mapper.device_display_mapper_plugin."
+        "DeviceDisplayMapperPlugin.request_usb_devices",
+        lambda self, cb: None,
+    )
+
+
+def test_health_is_ok_listening_on_successful_start(qtbot, fake_user_settings, monkeypatch):
+    _patch(monkeypatch, _FakeDeviceListener)
+    from src.plugins.device_display_mapper.device_display_mapper_plugin import (
+        DeviceDisplayMapperPlugin,
+    )
+    p = DeviceDisplayMapperPlugin(None)
+    qtbot.addWidget(p)
+    assert p.health().state is HealthState.OK
+    assert p.health().message == "Listening"
+
+
+def test_health_is_error_when_listener_construction_fails(qtbot, fake_user_settings, monkeypatch):
+    _patch(monkeypatch, _ExplodingListener)
+    from src.plugins.device_display_mapper.device_display_mapper_plugin import (
+        DeviceDisplayMapperPlugin,
+    )
+    p = DeviceDisplayMapperPlugin(None)
+    qtbot.addWidget(p)
+    assert p.health().state is HealthState.ERROR
+    assert "WMI unavailable" in p.health().message
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_device_display_mapper_health.py -v`
+Expected: FAIL — first test sees default empty health; second test crashes during `__init__` because `_start_runtime` does not catch the listener exception.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `src/plugins/device_display_mapper/device_display_mapper_plugin.py`.
+
+Add import:
+
+```python
+from ...base.health import HealthState
+```
+
+Replace `_start_runtime`:
+
+```python
+    def _start_runtime(self) -> None:
+        """Spin up the USB watcher and warm caches. Idempotent."""
+        if self.device_listener is None:
+            try:
+                self.device_listener = DeviceListener(self)
+            except Exception as e:
+                logging.exception("Failed to start device listener")
+                self._set_health(HealthState.ERROR, str(e))
+                return
+            self.device_listener.change_detected.connect(self.device_changed)
+        runner().submit(self._prewarm_monitor_cache)
+        self.request_usb_devices(lambda _devices: None)
+        self._set_health(HealthState.OK, "Listening")
+```
+
+(`logging` is already imported at the top of the module.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_device_display_mapper_health.py tests/test_device_display_mapper_plugin.py -v`
+Expected: All device-display-mapper tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/plugins/device_display_mapper/device_display_mapper_plugin.py tests/test_device_display_mapper_health.py
+git commit -m "feat: usb-display plugin reports health"
+```
+
+---
+
+### Task 7: UpdateChecker health wiring
+
+**Files:**
+- Modify: `src/components/update_checker.py`
+- Create: `tests/test_update_checker_health.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_update_checker_health.py`:
+
+```python
+from unittest.mock import patch
+
+import pytest
+
+from src.base.health import HealthState
+
+
+@pytest.fixture
+def checker(qtbot, fake_user_settings):
+    from src.components.update_checker import UpdateChecker
+    with patch.object(UpdateChecker, "check_updates"):
+        c = UpdateChecker(parent=None)
+        qtbot.addWidget(c)
+    return c
+
+
+def test_initial_health_is_ok_checking(checker):
+    assert checker.health().state is HealthState.OK
+    assert checker.health().message == "Checking…"
+
+
+def test_health_warning_when_check_returns_none(checker):
+    checker._busy = True
+    checker._on_check_finished(None)
+    assert checker.health().state is HealthState.WARNING
+    assert checker.health().message == "Check failed"
+
+
+def test_health_warning_when_watchdog_fires(checker):
+    checker._set_busy(True)
+    checker._interactive = False
+    checker._check_watchdog()
+    assert checker.health().state is HealthState.WARNING
+    assert checker.health().message == "Check timed out"
+
+
+def test_health_ok_up_to_date_when_remote_version_not_newer(checker):
+    checker._busy = True
+    with patch("src.components.update_checker.APP_INFO") as app_info:
+        app_info.APP_VERSION = "1.0.0"
+        checker._on_check_finished(("1.0.0", "https://example/installer.exe"))
+    assert checker.health().state is HealthState.OK
+    assert checker.health().message == "Up to date"
+
+
+def test_health_ok_update_available_when_remote_newer(qtbot, fake_user_settings):
+    from src.components.update_checker import UpdateChecker
+    with patch.object(UpdateChecker, "check_updates"):
+        c = UpdateChecker(parent=None)
+        qtbot.addWidget(c)
+    c._busy = True
+    with patch("src.components.update_checker.APP_INFO") as app_info, \
+         patch.object(c, "_confirm_update", return_value=False):
+        app_info.APP_VERSION = "1.0.0"
+        c._on_check_finished(("9.9.9", "https://example/installer.exe"))
+    assert c.health().state is HealthState.OK
+    assert c.health().message == "Update available 9.9.9"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_update_checker_health.py -v`
+Expected: 5 tests FAIL — health is default OK with empty message.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `src/components/update_checker.py`.
+
+Add import near the other base imports:
+
+```python
+from ..base.health import HealthState
+```
+
+In `UpdateChecker.__init__`, after `self._active_thread = None`, add:
+
+```python
+        self._set_health(HealthState.OK, "Checking…")
+```
+
+In `_check_watchdog`, after the `self._set_busy(False)` call, add:
+
+```python
+        self._set_health(HealthState.WARNING, "Check timed out")
+```
+
+In `_on_check_finished`, modify the `result is None` branch to set health before the `_set_busy(False)`:
+
+```python
+        if result is None:
+            if self._interactive:
+                QMessageBox.warning(
+                    self, 'Update check failed',
+                    'Could not check for updates. See logs for details.')
+            self._set_health(HealthState.WARNING, "Check failed")
+            self._set_busy(False)
+            return
+```
+
+Then in the same method, replace the version-comparison branch (the existing `if _parse_version(remote_version) <= _parse_version(APP_INFO.APP_VERSION):` block) so that both branches set health appropriately:
+
+```python
+        remote_version, installer_url = result
+        if _parse_version(remote_version) <= _parse_version(APP_INFO.APP_VERSION):
+            logging.info(f'No update is needed. Remote: {remote_version}, Local: {APP_INFO.APP_VERSION}')
+            if self._interactive:
+                QMessageBox.information(
+                    self, 'No update available',
+                    f'You are on the latest version ({APP_INFO.APP_VERSION}).')
+            self._set_health(HealthState.OK, "Up to date")
+            self._set_busy(False)
+            return
+
+        logging.info(f'Update available: {APP_INFO.APP_VERSION} -> {remote_version}')
+        self._set_health(HealthState.OK, f"Update available {remote_version}")
+        if not self._confirm_update(remote_version):
+            self._set_busy(False)
+            return
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_update_checker_health.py tests/test_update_checker_workers.py -v`
+Expected: All update-checker tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/update_checker.py tests/test_update_checker_health.py
+git commit -m "feat: auto-updater reports health"
+```
+
+---
+
+### Task 8: Health icon helper
+
+**Files:**
+- Create: `src/ui/health_icons.py`
+- Create: `tests/test_health_icons.py`
+
+The tray prefixes each row with a coloured 12×12 dot. Generated at runtime via `QPixmap`, cached as module-level constants. No new image assets — keeps `resources.qrc` untouched.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_health_icons.py`:
+
+```python
+from src.base.health import HealthState
+
+
+def test_icon_for_state_returns_qicon(qtbot):
+    from src.ui.health_icons import icon_for_state
+
+    for state in HealthState:
+        icon = icon_for_state(state)
+        assert not icon.isNull(), f"icon for {state} is null"
+
+
+def test_icon_is_cached_per_state(qtbot):
+    from src.ui.health_icons import icon_for_state
+
+    a = icon_for_state(HealthState.OK)
+    b = icon_for_state(HealthState.OK)
+    assert a is b
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_health_icons.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'src.ui.health_icons'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/ui/health_icons.py`:
+
+```python
+from functools import lru_cache
+
+from PySide6.QtCore import QSize, Qt
+from PySide6.QtGui import QColor, QIcon, QPainter, QPixmap
+
+from ..base.health import HealthState
+
+_COLORS: dict[HealthState, QColor] = {
+    HealthState.OK: QColor(76, 175, 80),       # green
+    HealthState.WARNING: QColor(255, 152, 0),  # amber
+    HealthState.ERROR: QColor(244, 67, 54),    # red
+    HealthState.DISABLED: QColor(158, 158, 158),  # grey
+}
+
+_ICON_SIZE = QSize(12, 12)
+
+
+@lru_cache(maxsize=None)
+def icon_for_state(state: HealthState) -> QIcon:
+    pix = QPixmap(_ICON_SIZE)
+    pix.fill(Qt.GlobalColor.transparent)
+    painter = QPainter(pix)
+    try:
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        painter.setBrush(_COLORS[state])
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.drawEllipse(0, 0, _ICON_SIZE.width(), _ICON_SIZE.height())
+    finally:
+        painter.end()
+    return QIcon(pix)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_health_icons.py -v`
+Expected: 2 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/health_icons.py tests/test_health_icons.py
+git commit -m "feat: coloured-dot icon helper for health states"
+```
+
+---
+
+### Task 9: TrayWidget summary line and Health submenu
+
+**Files:**
+- Modify: `src/ui/tray_widget.py`
+- Create: `tests/test_tray_widget_health.py`
+
+The tray's `_populate_main_menu` now starts with a disabled summary `QAction` and a `Health` submenu, then continues with each plugin's existing top-level menu actions. The summary text and aggregation rule come from a small helper `aggregate_health` that we test directly.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_tray_widget_health.py`:
+
+```python
+import pytest
+
+from src.base.health import HealthReport, HealthState
+
+
+def test_aggregate_health_all_ok():
+    from src.ui.tray_widget import aggregate_health
+
+    reports = [HealthReport(HealthState.OK, ""), HealthReport(HealthState.OK, "")]
+    state, text = aggregate_health(reports)
+    assert state is HealthState.OK
+    assert text == "Health: All OK"
+
+
+def test_aggregate_health_disabled_does_not_contribute():
+    from src.ui.tray_widget import aggregate_health
+
+    reports = [HealthReport(HealthState.OK, ""), HealthReport(HealthState.DISABLED, "")]
+    state, text = aggregate_health(reports)
+    assert state is HealthState.OK
+    assert text == "Health: All OK"
+
+
+def test_aggregate_health_warning_count():
+    from src.ui.tray_widget import aggregate_health
+
+    reports = [
+        HealthReport(HealthState.OK, ""),
+        HealthReport(HealthState.WARNING, "x"),
+        HealthReport(HealthState.WARNING, "y"),
+    ]
+    state, text = aggregate_health(reports)
+    assert state is HealthState.WARNING
+    assert text == "Health: 2 warning(s), 0 error(s)"
+
+
+def test_aggregate_health_error_outranks_warning():
+    from src.ui.tray_widget import aggregate_health
+
+    reports = [
+        HealthReport(HealthState.WARNING, ""),
+        HealthReport(HealthState.ERROR, ""),
+    ]
+    state, text = aggregate_health(reports)
+    assert state is HealthState.ERROR
+    assert text == "Health: 1 warning(s), 1 error(s)"
+
+
+class _StubPlugin:
+    def __init__(self, name: str, report: HealthReport):
+        self._name = name
+        self._report = report
+
+    def get_display_name(self):
+        return self._name
+
+    def is_toggleable(self):
+        return True
+
+    def is_enabled(self):
+        return self._report.state is not HealthState.DISABLED
+
+    def health(self):
+        return self._report
+
+    def retrieve_menus(self):
+        return []
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def tray_with_stubs(qtbot, fake_user_settings):
+    """Build a TrayWidget-like instance backed by a real QWidget so QAction
+    parenting works, but skipping the real plugin construction and the
+    QSystemTrayIcon side-effects."""
+    from PySide6.QtWidgets import QWidget
+
+    from src.ui.tray_widget import TrayWidget
+
+    class _TrayForTest(TrayWidget):
+        def __init__(self, stubs):
+            QWidget.__init__(self, parent=None)
+            self._config_dialog = None
+            self.logger_window = None
+            self.child_components = stubs
+
+    def _make(stubs):
+        tray = _TrayForTest(stubs)
+        qtbot.addWidget(tray)
+        return tray
+
+    return _make
+
+
+def test_main_menu_starts_with_summary_and_health_submenu(qtbot, tray_with_stubs):
+    plugins = [
+        _StubPlugin("Alpha", HealthReport(HealthState.OK, "Auto")),
+        _StubPlugin("Bravo", HealthReport(HealthState.WARNING, "Disconnected")),
+    ]
+    tray = tray_with_stubs(plugins)
+
+    from PySide6.QtWidgets import QMenu
+    menu = QMenu()
+    tray._populate_main_menu(menu)
+    actions = menu.actions()
+
+    assert actions[0].text() == "Health: 1 warning(s), 0 error(s)"
+    assert actions[0].isEnabled() is False  # summary line is informational
+
+    health_submenu = actions[1].menu()
+    assert health_submenu is not None
+    rows = [a.text() for a in health_submenu.actions()]
+    assert rows == ["Alpha — Auto", "Bravo — Disconnected"]
+
+
+def test_main_menu_summary_all_ok_when_only_disabled_remain(qtbot, tray_with_stubs):
+    plugins = [
+        _StubPlugin("Alpha", HealthReport(HealthState.DISABLED, "")),
+        _StubPlugin("Bravo", HealthReport(HealthState.OK, "Listening")),
+    ]
+    tray = tray_with_stubs(plugins)
+
+    from PySide6.QtWidgets import QMenu
+    menu = QMenu()
+    tray._populate_main_menu(menu)
+    assert menu.actions()[0].text() == "Health: All OK"
+
+
+def test_health_row_for_failing_plugin_does_not_break_menu(qtbot, tray_with_stubs):
+    class _Bad(_StubPlugin):
+        def health(self):
+            raise RuntimeError("boom")
+
+    plugins = [
+        _Bad("Bad", HealthReport(HealthState.OK, "")),
+        _StubPlugin("Good", HealthReport(HealthState.OK, "ok")),
+    ]
+    tray = tray_with_stubs(plugins)
+
+    from PySide6.QtWidgets import QMenu
+    menu = QMenu()
+    tray._populate_main_menu(menu)
+    health_submenu = menu.actions()[1].menu()
+    rows = [a.text() for a in health_submenu.actions()]
+    assert rows[0] == "Bad — health() failed"
+    assert rows[1] == "Good — ok"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_tray_widget_health.py -v`
+Expected: FAIL — `ImportError: cannot import name 'aggregate_health'`, and the menu does not start with a summary line.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `src/ui/tray_widget.py`.
+
+Add imports:
+
+```python
+import logging
+
+from ..base.health import HealthReport, HealthState
+from .health_icons import icon_for_state
+```
+
+Add a module-level helper above the `TrayWidget` class:
+
+```python
+def aggregate_health(reports: list[HealthReport]) -> tuple[HealthState, str]:
+    """Compute (worst-state, summary-text) for the tray top line.
+
+    Reports in DISABLED state are ignored entirely. When no plugins are
+    in WARNING or ERROR, the summary is "Health: All OK"; otherwise it's
+    "Health: N warning(s), M error(s)".
+    """
+    n_warning = sum(1 for r in reports if r.state is HealthState.WARNING)
+    n_error = sum(1 for r in reports if r.state is HealthState.ERROR)
+    if n_error > 0:
+        return HealthState.ERROR, f"Health: {n_warning} warning(s), {n_error} error(s)"
+    if n_warning > 0:
+        return HealthState.WARNING, f"Health: {n_warning} warning(s), {n_error} error(s)"
+    return HealthState.OK, "Health: All OK"
+```
+
+Replace `_populate_main_menu` with:
+
+```python
+    def _populate_main_menu(self, menu: QMenu) -> None:
+        menu.clear()
+
+        reports: list[tuple[BaseWidget, HealthReport]] = []
+        for plugin in self.child_components:
+            try:
+                reports.append((plugin, plugin.health()))
+            except Exception:
+                logging.exception("plugin %s health() raised", plugin.__class__.__name__)
+                reports.append((plugin, HealthReport(HealthState.WARNING, "health() failed")))
+
+        worst_state, summary_text = aggregate_health([r for _, r in reports])
+        summary_action = QAction(summary_text, self)
+        summary_action.setIcon(icon_for_state(worst_state))
+        summary_action.setEnabled(False)
+        menu.addAction(summary_action)
+
+        health_submenu = QMenu("Health", menu)
+        for plugin, report in reports:
+            row = QAction(f"{plugin.get_display_name()} — {report.message}", self)
+            row.setIcon(icon_for_state(report.state))
+            row.setEnabled(False)
+            health_submenu.addAction(row)
+        menu.addMenu(health_submenu)
+        menu.addSeparator()
+
+        for plugin, _ in reports:
+            if plugin.is_toggleable() and not plugin.is_enabled():
+                continue
+            for action in plugin.retrieve_menus():
+                if isinstance(action, QMenu):
+                    menu.addMenu(action)
+                elif isinstance(action, QAction):
+                    menu.addAction(action)
+        menu.addSeparator()
+
+        config_action = QAction('Configuration...', self)
+        config_action.triggered.connect(self.open_configuration_dialog)
+        menu.addAction(config_action)
+        menu.addSeparator()
+
+        logs_action = QAction('View Logs', self)
+        logs_action.triggered.connect(self.open_logs_window)
+        menu.addAction(logs_action)
+
+        about_action = QAction('About...', self)
+        about_action.triggered.connect(self.open_about_dialog)
+        menu.addAction(about_action)
+        menu.addSeparator()
+
+        quit_action = QAction('Quit', self)
+        quit_action.triggered.connect(self.close_slot)
+        menu.addAction(quit_action)
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_tray_widget_health.py -v`
+Expected: 7 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/tray_widget.py tests/test_tray_widget_health.py
+git commit -m "feat: tray menu shows health summary line and submenu"
+```
+
+---
+
+### Task 10: Manual smoke + full suite
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `./env/Scripts/python.exe -m pytest tests/ -q`
+Expected: full green.
+
+- [ ] **Step 2: Run flake8 to match CI**
+
+Run: `./env/Scripts/python.exe -m flake8 src tests`
+Expected: no output (clean).
+
+- [ ] **Step 3: Manual smoke test**
+
+Stop any running tray Python:
+
+```powershell
+Get-Process | Where-Object { $_.Path -like "*\swiss-windows-knife\env\Scripts\python.exe" } | Stop-Process -Force
+```
+
+Then launch the dev tray:
+
+```bash
+./env/Scripts/python.exe -m src.swiss_windows_knife
+```
+
+Verify in the tray menu:
+- Top line reads `Health: All OK` (green dot) when all plugins are OK; or `Health: N warning(s), M error(s)` with a coloured dot.
+- A `Health` submenu lists each plugin with state colour and short message.
+- Disabled plugins (toggle one off in `Configuration → Plugins`) appear in the submenu with a grey dot and `Disabled` placeholder.
+- Toggling a plugin off/on flips it between `Disabled` and its real state.
+- Disconnect the network briefly: the HA row flips from `Connected` to `Disconnected` and back when restored.
+
+- [ ] **Step 4: Push branch**
+
+```bash
+git push -u origin feat/plugin-health-status
+```
+
+- [ ] **Step 5: Open the PR**
+
+Use whatever PR flow the user prefers. Title example: `feat: plugin health status in tray menu`. Body bullets: summary line + Health submenu, per-plugin states, replaces HA's old status submenu.
+
+---
+
+## Self-review notes
+
+**Spec coverage:**
+- Tri-state + Disabled — Task 1.
+- `BaseWidget.health()` / `_set_health` / disabled short-circuit — Task 2.
+- `MqttSession.on_disconnected` — Task 3.
+- HA states (Not configured / Connecting… / Connected / Disconnected) and removal of legacy submenu — Task 4.
+- DisplayImageTuner OK/Warning + mode message — Task 5.
+- DeviceDisplayMapper OK/Error — Task 6.
+- UpdateChecker OK/Warning across all branches — Task 7.
+- Coloured-dot icons cached at module level — Task 8.
+- TrayWidget summary line + Health submenu + worst-state aggregation + per-plugin failure isolation — Task 9.
+- Manual smoke + CI parity — Task 10.
+
+**Type / signature consistency:** `HealthReport(state, message)`, `HealthState.{OK, WARNING, ERROR, DISABLED}`, `BaseWidget.health()`, `BaseWidget._set_health(state, message)`, `MqttSession.on_disconnected: Callable[[], None] | None` — used identically across all tasks.
+
+**Placeholder scan:** No TBDs, no "implement later", no "similar to Task N" handwaves. Every code step shows the actual code.

--- a/docs/superpowers/plans/2026-04-30-plugin-health-status.md
+++ b/docs/superpowers/plans/2026-04-30-plugin-health-status.md
@@ -320,6 +320,7 @@ def test_health_is_warning_connecting_after_session_starts(qtbot, configured_set
 def test_health_is_ok_connected_after_on_connect(qtbot, configured_settings, fake_paho_client):
     plugin = _make_plugin(qtbot)
     fake_paho_client[0].fire_on_connect(rc=0)
+    qtbot.wait(20)  # cross to GUI thread via QMetaObject.invokeMethod
     report = plugin.health()
     assert report.state is HealthState.OK
     assert report.message == "Connected"

--- a/docs/superpowers/plans/2026-04-30-tray-icon-health-overlay.md
+++ b/docs/superpowers/plans/2026-04-30-tray-icon-health-overlay.md
@@ -1,0 +1,467 @@
+# Tray Icon Health Overlay Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Overlay a coloured dot in the top-right corner of the tray icon reflecting aggregate plugin health, refreshing live whenever any plugin's health or toggle state changes.
+
+**Architecture:** Add a `health_changed = Signal()` on `BaseWidget`, emitted by `_set_health` (on real state-or-message change) and by `set_enabled` (on toggle transitions). `TrayWidget` connects each plugin's signal to a slot that aggregates health and rebuilds the tray icon via a new `tray_icon_for_state(HealthState)` helper.
+
+**Tech Stack:** Python 3.12, PySide6 (`Signal`, `QPixmap`, `QPainter`, `QIcon`), pytest-qt.
+
+**Branch:** `feat/plugin-health-status` (already in flight as PR #16; this set of commits adds the icon overlay to the same PR).
+
+**Spec:** `docs/superpowers/specs/2026-04-30-tray-icon-health-overlay-design.md` (committed at e42a6d2).
+
+---
+
+### Task 1: BaseWidget gains `health_changed` Signal and emits on `_set_health` change
+
+**Files:**
+- Modify: `src/base/base_widget.py`
+- Modify: `tests/test_base_widget.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_base_widget.py`:
+
+```python
+def test_health_changed_emits_on_state_change(qtbot, fake_user_settings):
+    from src.base.health import HealthState
+    widget = BaseWidget(None)
+    qtbot.addWidget(widget)
+
+    fired: list[None] = []
+    widget.health_changed.connect(lambda: fired.append(None))
+
+    widget._set_health(HealthState.WARNING, "x")
+    assert fired == [None]
+
+
+def test_health_changed_emits_on_message_change(qtbot, fake_user_settings):
+    from src.base.health import HealthState
+    widget = BaseWidget(None)
+    qtbot.addWidget(widget)
+    widget._set_health(HealthState.OK, "Auto")
+
+    fired: list[None] = []
+    widget.health_changed.connect(lambda: fired.append(None))
+
+    widget._set_health(HealthState.OK, "Manual 60")
+    assert fired == [None]
+
+
+def test_health_changed_does_not_emit_on_noop(qtbot, fake_user_settings):
+    from src.base.health import HealthState
+    widget = BaseWidget(None)
+    qtbot.addWidget(widget)
+    widget._set_health(HealthState.OK, "Auto")
+
+    fired: list[None] = []
+    widget.health_changed.connect(lambda: fired.append(None))
+
+    widget._set_health(HealthState.OK, "Auto")  # same value
+    assert fired == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_base_widget.py -v -k health_changed`
+Expected: FAIL — `AttributeError: 'BaseWidget' object has no attribute 'health_changed'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `src/base/base_widget.py`. Add the import at the top alongside the existing PySide6 imports:
+
+```python
+from PySide6.QtCore import Signal
+```
+
+Add the class-level signal declaration just after the `display_name` class attribute (before `__init__`):
+
+```python
+class BaseWidget(QWidget):
+
+    display_name: str = ""
+
+    health_changed = Signal()
+```
+
+Replace `_set_health` with the change-detecting variant:
+
+```python
+    def _set_health(self, state: HealthState, message: str) -> None:
+        new_report = HealthReport(state, message)
+        if new_report == self._current_health:
+            return
+        self._current_health = new_report
+        self.health_changed.emit()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_base_widget.py -v`
+Expected: All tests PASS (existing 13 + 3 new = 16).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/base/base_widget.py tests/test_base_widget.py
+git commit -m "feat: BaseWidget emits health_changed when state/message changes"
+```
+
+---
+
+### Task 2: BaseWidget emits `health_changed` on `set_enabled` transitions
+
+**Files:**
+- Modify: `src/base/base_widget.py`
+- Modify: `tests/test_base_widget.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_base_widget.py`:
+
+```python
+def test_health_changed_emits_on_set_enabled_transition(qtbot, fake_user_settings):
+    widget = BaseWidget(None, is_toggleable=True, is_enabled=True)
+    qtbot.addWidget(widget)
+
+    fired: list[None] = []
+    widget.health_changed.connect(lambda: fired.append(None))
+
+    widget.set_enabled(False)
+    assert fired == [None]
+
+
+def test_health_changed_does_not_emit_on_set_enabled_noop(qtbot, fake_user_settings):
+    widget = BaseWidget(None, is_toggleable=True, is_enabled=True)
+    qtbot.addWidget(widget)
+
+    fired: list[None] = []
+    widget.health_changed.connect(lambda: fired.append(None))
+
+    widget.set_enabled(True)  # already True
+    assert fired == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_base_widget.py -v -k set_enabled_transition -k set_enabled_noop`
+Expected: 1 FAIL (the transition test sees `fired == []`), 1 PASS (the noop test happens to pass already since no signal fires).
+
+Run the full file to be sure:
+Run: `./env/Scripts/python.exe -m pytest tests/test_base_widget.py -v`
+Expected: 1 NEW failure (transition).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `src/base/base_widget.py`. Replace `set_enabled`:
+
+```python
+    def set_enabled(self, enabled: bool) -> None:
+        if self._is_enabled == enabled:
+            return
+        self._is_enabled = enabled
+        UserSettings.instance().set(_settings_key(self.__class__), enabled)
+        logging.info(f'Plugin {self.__class__.__name__} is enabled: {enabled}')
+        self.status_changed(enabled)
+        self.health_changed.emit()
+```
+
+(The new line is `self.health_changed.emit()` at the end. The early-return at the top means it only fires on real toggle transitions.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_base_widget.py -v`
+Expected: All tests PASS (16 + 2 new = 18).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/base/base_widget.py tests/test_base_widget.py
+git commit -m "feat: BaseWidget emits health_changed on toggle transitions"
+```
+
+---
+
+### Task 3: `tray_icon_for_state` helper
+
+**Files:**
+- Modify: `src/ui/health_icons.py`
+- Modify: `tests/test_health_icons.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_health_icons.py`:
+
+```python
+def test_tray_icon_for_state_returns_non_null(qtbot):
+    # Resources must be loaded so :/icons/coat-of-arms.ico resolves.
+    from src import resources  # noqa: F401
+    from src.ui.health_icons import tray_icon_for_state
+
+    for state in HealthState:
+        icon = tray_icon_for_state(state)
+        assert not icon.isNull(), f"tray icon for {state} is null"
+
+
+def test_tray_icon_for_state_is_cached(qtbot):
+    from src import resources  # noqa: F401
+    from src.ui.health_icons import tray_icon_for_state
+
+    a = tray_icon_for_state(HealthState.OK)
+    b = tray_icon_for_state(HealthState.OK)
+    assert a is b
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_health_icons.py -v`
+Expected: 2 new tests FAIL — `ImportError: cannot import name 'tray_icon_for_state' from 'src.ui.health_icons'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `src/ui/health_icons.py`. Add a constant near `_ICON_SIZE`:
+
+```python
+_TRAY_ICON_SIZE = QSize(64, 64)
+_TRAY_DOT_RECT = (40, 0, 24, 24)  # x, y, width, height — top-right
+```
+
+Append the helper at the bottom of the file:
+
+```python
+@cache
+def tray_icon_for_state(state: HealthState) -> QIcon:
+    """Return the app's tray icon overlaid with a coloured dot for `state`.
+
+    The dot sits in the top-right corner of a 64x64 composed pixmap;
+    Windows downsamples for the systray slot. Cached per state.
+    """
+    base = QIcon(":/icons/coat-of-arms.ico").pixmap(_TRAY_ICON_SIZE)
+    composed = QPixmap(_TRAY_ICON_SIZE)
+    composed.fill(Qt.GlobalColor.transparent)
+    painter = QPainter(composed)
+    try:
+        painter.drawPixmap(0, 0, base)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        painter.setBrush(_COLORS[state])
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.drawEllipse(*_TRAY_DOT_RECT)
+    finally:
+        painter.end()
+    icon = QIcon()
+    icon.addPixmap(composed, QIcon.Mode.Normal)
+    icon.addPixmap(composed, QIcon.Mode.Disabled)
+    return icon
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_health_icons.py -v`
+Expected: 4 tests PASS (2 existing + 2 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/health_icons.py tests/test_health_icons.py
+git commit -m "feat: tray_icon_for_state composes coat-of-arms with health dot"
+```
+
+---
+
+### Task 4: `TrayWidget` refreshes its icon on `health_changed`
+
+**Files:**
+- Modify: `src/ui/tray_widget.py`
+- Modify: `tests/test_tray_widget_health.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_tray_widget_health.py`:
+
+```python
+def test_tray_icon_refreshes_on_plugin_health_change(qtbot, fake_user_settings):
+    """The tray's icon refresh slot is wired to each plugin's health_changed
+    signal and rebuilds the icon via tray_icon_for_state."""
+    from unittest.mock import MagicMock
+
+    from PySide6.QtCore import Signal
+    from PySide6.QtWidgets import QWidget
+
+    from src import resources  # noqa: F401
+    from src.base.health import HealthState
+    from src.ui.tray_widget import TrayWidget
+
+    class _SignalingPlugin(QWidget):
+        health_changed = Signal()
+
+        def __init__(self, name: str, report: HealthReport):
+            super().__init__()
+            self._name = name
+            self._report = report
+
+        def get_display_name(self):
+            return self._name
+
+        def is_toggleable(self):
+            return True
+
+        def is_enabled(self):
+            return self._report.state is not HealthState.DISABLED
+
+        def health(self):
+            return self._report
+
+        def retrieve_menus(self):
+            return []
+
+        def set_report(self, report: HealthReport) -> None:
+            self._report = report
+            self.health_changed.emit()
+
+    plugins = [
+        _SignalingPlugin("Alpha", HealthReport(HealthState.OK, "ok")),
+        _SignalingPlugin("Bravo", HealthReport(HealthState.OK, "ok")),
+    ]
+
+    class _TrayForTest(TrayWidget):
+        def __init__(self, components):
+            QWidget.__init__(self, parent=None)
+            self._config_dialog = None
+            self.logger_window = None
+            self.child_components = components
+            self._tray_icon = MagicMock()
+            self._wire_health_signals()
+            self._refresh_tray_icon()
+
+    tray = _TrayForTest(plugins)
+    qtbot.addWidget(tray)
+
+    # Initial refresh in __init__ called setIcon once with the OK icon.
+    assert tray._tray_icon.setIcon.call_count == 1
+
+    tray._tray_icon.setIcon.reset_mock()
+    plugins[1].set_report(HealthReport(HealthState.WARNING, "broker down"))
+    assert tray._tray_icon.setIcon.call_count == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_tray_widget_health.py::test_tray_icon_refreshes_on_plugin_health_change -v`
+Expected: FAIL — `AttributeError: 'TrayWidget' object has no attribute '_wire_health_signals'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Modify `src/ui/tray_widget.py`. Add the import alongside the existing health-icons import:
+
+```python
+from .health_icons import icon_for_state, tray_icon_for_state
+```
+
+In `TrayWidget.__init__`, after `self._tray_icon.show()`, add:
+
+```python
+        self._wire_health_signals()
+        self._refresh_tray_icon()
+```
+
+Add the two new methods on the class (place them near `_populate_main_menu`):
+
+```python
+    def _wire_health_signals(self) -> None:
+        for plugin in self.child_components:
+            plugin.health_changed.connect(self._refresh_tray_icon)
+
+    @Slot()
+    def _refresh_tray_icon(self) -> None:
+        reports: list[HealthReport] = []
+        for plugin in self.child_components:
+            try:
+                reports.append(plugin.health())
+            except Exception:
+                logging.exception("plugin %s health() raised", plugin.__class__.__name__)
+                reports.append(HealthReport(HealthState.WARNING, "health() failed"))
+        worst_state, _ = aggregate_health(reports)
+        self._tray_icon.setIcon(tray_icon_for_state(worst_state))
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `./env/Scripts/python.exe -m pytest tests/test_tray_widget_health.py -v`
+Expected: All 7 tests PASS (6 existing + 1 new).
+
+Then run the full suite to confirm no regressions:
+Run: `./env/Scripts/python.exe -m pytest tests/ -q`
+Expected: 230 passed (222 baseline + 3 from Task 1 + 2 from Task 2 + 2 from Task 3 + 1 from Task 4). The suite must be fully green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/ui/tray_widget.py tests/test_tray_widget_health.py
+git commit -m "feat: tray icon shows aggregate health overlay"
+```
+
+---
+
+### Task 5: Manual smoke + push
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `./env/Scripts/python.exe -m pytest tests/ -q`
+Expected: full green.
+
+- [ ] **Step 2: Run ruff to match CI**
+
+Run: `./env/Scripts/python.exe -m ruff check src tests`
+Expected: `All checks passed!`.
+
+- [ ] **Step 3: Manual smoke test**
+
+Stop any running tray Python:
+
+```powershell
+Get-Process | Where-Object { $_.Path -like "*\swiss-windows-knife\env\Scripts\python.exe" } | Stop-Process -Force
+```
+
+Then launch the dev tray:
+
+```bash
+./env/Scripts/python.exe -m src.swiss_windows_knife
+```
+
+Verify:
+- The tray icon shows a small green dot in its top-right corner.
+- Briefly disconnecting from the network: the dot flips to amber when HA reports `Disconnected` and back to green on reconnect.
+- Toggling a plugin off in `Configuration → Plugins`: the icon refreshes (the dot stays green because Disabled doesn't contribute, but you can verify the path was exercised by checking the menu's `Health: …` title).
+- Forcing a fake VCPError (e.g., temporarily renaming the brightness device, or just verifying via the unit tests in Task 1): if any plugin reports Warning, the dot is amber.
+
+- [ ] **Step 4: Push**
+
+```bash
+git push
+```
+
+The branch is already tracking `origin/feat/plugin-health-status` (from earlier in this PR), so the new commits land on PR #16 automatically.
+
+---
+
+## Self-review notes
+
+**Spec coverage:**
+
+- Always-show coloured dot reflecting aggregate state — Task 4 (`_refresh_tray_icon` calls `setIcon(tray_icon_for_state(worst_state))`).
+- Push model via `health_changed` signal — Task 1 (`_set_health` emit) + Task 2 (`set_enabled` emit).
+- DISABLED ignored in aggregate, all-disabled → green — already handled by `aggregate_health` from the parent feature; the new code reuses it unchanged.
+- Initial paint at `__init__` so the icon reflects starting state — Task 4 (`self._refresh_tray_icon()` call after `_wire_health_signals`).
+- Per-plugin failure isolation — Task 4 (`try/except Exception` around `plugin.health()` in the slot, mirroring `_populate_main_menu`'s pattern).
+- 64×64 base, 24-px dot at `(40, 0, 24, 24)` — Task 3 helper.
+- `@cache` on the icon helper — Task 3.
+- Both Normal and Disabled QIcon modes registered — Task 3.
+
+**Type / signature consistency:**
+- `health_changed = Signal()` (no payload) — Task 1, used identically in Tasks 2 and 4.
+- `tray_icon_for_state(state: HealthState) -> QIcon` — Task 3, called with the same signature in Task 4.
+- `aggregate_health` is an existing helper (parent feature); the new slot calls it with a `list[HealthReport]` (no plugin pairs), matching its existing signature.
+
+**Placeholder scan:** No TBDs, no "implement later", no "similar to Task N" handwaves. Every code step shows the actual code. Test inputs (`"x"`, `"broker down"`, etc.) are concrete strings.

--- a/docs/superpowers/specs/2026-04-30-plugin-health-status-design.md
+++ b/docs/superpowers/specs/2026-04-30-plugin-health-status-design.md
@@ -1,0 +1,202 @@
+# Plugin health status design
+
+## Goal
+
+Surface, in the tray menu, whether each plugin is functioning. Today only `HomeAssistantMqttPubPlugin` exposes any status (a disabled `Configured` / `Not configured` action), and even that doesn't reflect whether the MQTT session is actually connected. The other plugins surface no health information at all, so the user has to open `View Logs` to know whether USB monitoring is alive or whether `monitorcontrol` is failing silently.
+
+The user wants a single consolidated view of plugin health, plus an at-a-glance summary at the top of the tray that says whether *anything* needs attention.
+
+## Behavior
+
+The tray's main menu grows two new elements at the top:
+
+1. **A single summary line** showing the worst aggregate state across all enabled plugins:
+   - `Health: All OK` (green dot)
+   - `Health: N warning(s), M error(s)` (amber dot if no errors, red if any)
+
+   Disabled plugins do not contribute to the aggregate. The summary line is not clickable; it is purely a status indicator.
+
+2. **A `Health` submenu** with one row per plugin (including non-toggleable ones like `Auto-updater`):
+   - `● Display brightness — Auto`
+   - `● Monitor input switch — Listening`
+   - `● Home Assistant — Connected`
+   - `● Auto-updater — Up to date`
+
+   Disabled plugins still appear, greyed out, with state `Disabled`.
+
+Clicking a row in the `Health` submenu does nothing — it is informational. Existing plugin tray actions (brightness/contrast control menus, `Check for updates...`, etc.) remain where they are. The `Home Assistant` submenu's existing `Configured / Not configured` action is removed in favor of the unified Health view.
+
+### State semantics per plugin
+
+| Plugin | OK | Warning | Error | Disabled |
+|---|---|---|---|---|
+| **Display brightness & contrast** | last `monitorcontrol` op succeeded; message reflects current mode (`Auto` / `Manual N`) | last `monitorcontrol` op raised `VCPError` (auto-clears on next successful op) | (no error state in v1) | user toggled off |
+| **Monitor input switch on USB events** | `DeviceListener` running; message `Listening` | (no warning state) | listener failed to start (exception raised in `_start_runtime`) | user toggled off |
+| **Home Assistant (MQTT)** | session connected (paho `on_connect` fired); message `Connected` | (a) configured but not yet connected / disconnected; (b) not configured at all; messages `Connecting…` / `Disconnected` / `Not configured` | (no error state in v1; broker auth failures show as warning until reconnect succeeds) | user toggled off |
+| **Auto-updater** | last check succeeded; message `Up to date` or `Update available vN.N.N` | last check failed (`result is None` from `_on_check_finished`) or watchdog fired; message `Check failed` | (no error state) | n/a (`is_toggleable=False`) |
+
+### Aggregation rule
+
+Worst-state-wins, ignoring `Disabled`:
+
+- any plugin in `Error` → top line is red, `Health: N warning(s), M error(s)`
+- else any plugin in `Warning` → top line is amber, `Health: N warning(s), 0 errors`
+- else → top line is green, `Health: All OK`
+
+Counts include only plugins in the corresponding state (so warnings count only warnings, errors count only errors). A purely disabled set yields `Health: All OK` because no enabled plugins are in trouble.
+
+## Architecture
+
+### `src/base/health.py` (new)
+
+```python
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class HealthState(StrEnum):
+    OK = "ok"
+    WARNING = "warning"
+    ERROR = "error"
+    DISABLED = "disabled"
+
+
+@dataclass(frozen=True)
+class HealthReport:
+    state: HealthState
+    message: str
+```
+
+`HealthReport` is the single value plugins expose. `message` is a short human-readable string (e.g. `"Connected"`, `"Broker unreachable"`, `"Auto"`, `"Manual 60"`); the tray uses it verbatim as the row label after the dot.
+
+### `src/base/base_widget.py` (modified)
+
+`BaseWidget` gains:
+
+- An attribute `self._current_health: HealthReport = HealthReport(HealthState.OK, "")`, initialized in `__init__`.
+- A method `health() -> HealthReport`: returns `HealthReport(HealthState.DISABLED, "")` if `self.is_toggleable() and not self.is_enabled()`, otherwise returns `self._current_health`. Contract: **must be cheap and non-blocking; no I/O, no DDC calls, no socket reads.** Subclasses do not override this — they update `_current_health` instead.
+- A protected helper `_set_health(state: HealthState, message: str) -> None`: replaces `self._current_health`. Plugins call this from inside whatever event path changed their health.
+
+The disabled-state short-circuit lives in `BaseWidget.health()` rather than in each plugin so plugins do not need to special-case it.
+
+### Plugin update points
+
+Each plugin maintains its own `_current_health` from inside its existing event paths. No new threads, no new timers.
+
+**`DisplayImageTunerPlugin`**
+- Initial: `_set_health(OK, mode_message())` where `mode_message()` returns `"Auto"` if `user_settings.get('brightness') is None`, else `f"Manual {value}"`.
+- Inside `_apply_brightness` / `_apply_contrast` after a successful `monitor.set_*` call: `_set_health(OK, mode_message())`.
+- Inside the `except (ValueError, monitorcontrol.VCPError)` branch: `_set_health(WARNING, f"Monitor error: {e}")`.
+- In `change_*_manual` / `change_*_automatic`: re-set health with `mode_message()` while preserving the current state — i.e. if currently OK, stay OK with the new mode message; if currently Warning, keep the Warning message until the next successful apply replaces it.
+- In `status_changed(False)`: nothing to do; `BaseWidget.health()` already returns `Disabled`.
+
+**`DeviceDisplayMapperPlugin`**
+- Initial: in `__init__` after `_start_runtime()` succeeds, `_set_health(OK, "Listening")`. If the listener constructor raises, catch it, log, and `_set_health(ERROR, str(e))`. Today `_start_runtime` is not wrapped in try/except — it will be, narrowly around the `DeviceListener(self)` construction.
+- In `status_changed(True)`: same logic (start succeeded → OK, raised → ERROR).
+- In `status_changed(False)`: nothing — covered by `BaseWidget.health()`.
+
+**`HomeAssistantMqttPubPlugin`**
+- Initial: `_set_health(WARNING, "Not configured")` if `not self.is_homeassistant_configured`; otherwise `_set_health(WARNING, "Connecting…")` until paho's `on_connect` fires.
+- In `_dispatch_on_connected` (already triggered by paho): `_set_health(OK, "Connected")`.
+- New: `MqttSession` gains an `on_disconnected: Callable[[], None] | None` hook called from paho's `on_disconnect` callback (paho-mqtt already invokes `_on_disconnect` on the network thread; we already cross over to the GUI thread for the on-connect case via `QMetaObject.invokeMethod`, so we mirror that pattern). The plugin sets it to a method that posts back to the GUI thread and calls `_set_health(WARNING, "Disconnected")`.
+- In `reload_session`: re-emit the appropriate initial state after teardown (`Not configured` if config is incomplete; `Connecting…` if it'll start a new session).
+- In `closeEvent`: nothing special; the tray will be tearing down too.
+
+**`UpdateChecker`**
+- Initial: `_set_health(OK, "Checking…")` since the first check fires on a `QTimer.singleShot(0, …)` from `__init__`.
+- In `_on_check_finished` success branch (no update available): `_set_health(OK, "Up to date")`.
+- In `_on_check_finished` "update available": `_set_health(OK, f"Update available {remote_version}")` — this is informational, not a problem.
+- In `_on_check_finished` `result is None` branch: `_set_health(WARNING, "Check failed")`.
+- In `_check_watchdog` after timeout: `_set_health(WARNING, "Check timed out")`.
+
+### `src/ui/tray_widget.py` (modified)
+
+`_populate_main_menu` is restructured:
+
+1. Read each plugin's `health()` once into a local list `[(plugin, report), …]` (4 attribute reads).
+2. Compute aggregate counts: `n_warning = sum(1 for _, r in reports if r.state == WARNING)`, similarly errors. Decide overall worst state.
+3. Build the summary `QAction` (disabled, no slot) with text `Health: All OK` / `Health: N warning(s), M error(s)` and a coloured-dot icon based on aggregate worst-state.
+4. Build the `Health` submenu: one disabled `QAction` per plugin titled `{display_name} — {message}`, prefixed with a coloured dot icon based on `report.state`. Plugins are listed in the same order as `child_components`; disabled plugins are not separated, just greyed out via the icon.
+5. Then continue as today: existing per-plugin tray actions, separator, Configuration / View Logs / About / Quit.
+
+For the coloured-dot icons, generate small `QPixmap`s at runtime (16×16 filled circles, one per state) cached as module-level constants so we are not recomputing them per menu open. No new files in `resources.qrc`.
+
+### Removal of the existing HA status submenu
+
+`HomeAssistantMqttPubPlugin.retrieve_menus()` currently returns a `Home Assistant` submenu containing only a disabled `Configured` / `Not configured` row. With the unified Health view that information is redundant; `retrieve_menus()` returns `[]`. Anything actionable HA grows in the future can be added back to its own submenu.
+
+## Data flow
+
+```
+plugin async event (paho callback / monitor runner result / QThread finished)
+    │
+    └──→ plugin._set_health(state, message)
+                │
+                └──→ self._current_health = HealthReport(...)
+                                 │
+                                 ▼
+user clicks tray  ──→  aboutToShow  ──→  _populate_main_menu
+                                                │
+                                                └──→ for each plugin: plugin.health()
+                                                                            │
+                                                                            └──→ return self._current_health
+                                                                                  (unless toggled off → DISABLED)
+```
+
+Cost on tray-open: 4 attribute reads + worst-state aggregation + 5 `QAction` creations. Sub-millisecond. The non-blocking contract on `health()` is enforced socially (docstring) and structurally (default implementation is a single attribute read).
+
+## Error handling
+
+- `_set_health` is the only mutator and only accepts `HealthState` enum values, so corrupted states are impossible.
+- If a plugin forgets to call `_set_health` after a failure, the worst that happens is the tray shows stale info; nothing crashes.
+- If `health()` raises (e.g. due to a future plugin overriding it incorrectly), the tray catches per-plugin exceptions in `_populate_main_menu`, logs `logging.exception("plugin health() raised")`, and falls back to `HealthReport(WARNING, "health() failed")` for that row so one broken plugin cannot prevent the rest of the menu from rendering.
+
+## Testing
+
+`pytest-qt` covers all interactive bits.
+
+**`tests/base/test_base_widget_health.py`** (new)
+- `health()` returns `Disabled` when `is_toggleable() and not is_enabled()`, regardless of `_current_health`.
+- `health()` returns `_current_health` when enabled.
+- `health()` returns `_current_health` for non-toggleable widgets even with `is_enabled() == False` (defensive — `is_toggleable=False` widgets should not have `is_enabled` flipped, but the contract is "DISABLED only for toggleable-and-off").
+- `_set_health` updates `_current_health` exactly once per call.
+
+**`tests/plugins/home_assistant_mqtt_pub/test_health.py`** (new)
+- With no MQTT config, plugin reports `Warning: Not configured`.
+- With config but before `_dispatch_on_connected` fires, plugin reports `Warning: Connecting…`.
+- After `_dispatch_on_connected`: `OK: Connected`.
+- After the new `on_disconnected` hook fires: `Warning: Disconnected`.
+
+**`tests/plugins/display_image_tuner/test_health.py`** (new)
+- Initial state is OK with current mode message.
+- Forcing `_apply_brightness` to raise `monitorcontrol.VCPError` flips to `Warning`.
+- Next successful apply restores `OK`.
+
+**`tests/plugins/device_display_mapper/test_health.py`** (new)
+- Successful start → `OK: Listening`.
+- `DeviceListener` constructor raising → `Error: <reason>`.
+
+**`tests/components/test_update_checker_health.py`** (new)
+- Initial state `OK: Checking…`.
+- `_on_check_finished(None)` → `Warning: Check failed`.
+- `_on_check_finished(("v9.9.9", "url"))` (newer) → `OK: Update available v9.9.9` (the version-skipping logic in `_confirm_update` is unrelated to health).
+- Watchdog firing → `Warning: Check timed out`.
+
+**`tests/ui/test_tray_widget_health.py`** (new)
+- Build a `TrayWidget` with three stub plugins reporting `OK` / `WARNING` / `ERROR`. Assert summary text is `Health: 1 warning(s), 1 error(s)` and the summary action has the red dot icon.
+- All-OK plugins → summary text is `Health: All OK`, green icon.
+- One disabled plugin + two OK plugins → summary text is `Health: All OK` (disabled does not contribute to counts), and the disabled plugin appears in the submenu with the grey dot.
+- A plugin whose `health()` raises → tray still renders; that row shows `Warning: health() failed`.
+
+CI runs all of this with `QT_QPA_PLATFORM=offscreen`.
+
+## Out of scope
+
+- Live updates while the tray menu is open. Tray menus close on click anyway, and pull-on-`aboutToShow` is sufficient.
+- Tray icon colour reflecting aggregate health. Could be added later if the user wants ambient awareness without opening the menu.
+- Multi-component health per plugin (e.g. HA reporting connection + each entity sampler separately). Plugins that internally have multiple sub-components aggregate worst-state-wins inside themselves; the tray sees one row per plugin.
+- Click actions on Health rows (e.g. "click HA error → open MQTT config panel"). Informational only in v1.
+
+## Conventional-commits / version impact
+
+This is a `feat:` commit (minor bump): a new user-visible capability. The MQTT `on_disconnected` hook addition is internal plumbing for the same feature — it ships in the same commit (or a same-PR predecessor commit, also tagged `feat:` since it lands a new public hook on `MqttSession`). Removing the existing `Configured / Not configured` HA submenu row is part of the same `feat:` (the unified Health view replaces it).

--- a/docs/superpowers/specs/2026-04-30-tray-icon-health-overlay-design.md
+++ b/docs/superpowers/specs/2026-04-30-tray-icon-health-overlay-design.md
@@ -1,0 +1,106 @@
+# Tray icon health overlay design
+
+## Goal
+
+Surface aggregate plugin health on the tray icon itself — a small coloured dot in the top-right corner — so the user sees a Warning or Error without opening the menu. The plugin-health-status feature already shipped a `Health: …` submenu (PR #16); this design adds the at-a-glance indicator that the parent design doc explicitly deferred ("Tray icon colour reflecting aggregate health … could be added later if the user wants ambient awareness without opening the menu").
+
+## Behaviour
+
+The tray icon always shows a coloured dot in its top-right corner reflecting the worst non-disabled health state across all plugins:
+
+- **Green** — `HealthState.OK` for every enabled plugin.
+- **Amber** — at least one plugin in `HealthState.WARNING` (and none in ERROR).
+- **Red** — at least one plugin in `HealthState.ERROR`.
+
+The dot is always visible (the user explicitly chose this over a hide-when-OK policy). DISABLED plugins do not contribute to the aggregate; if every plugin is DISABLED, the aggregate falls back to OK and the dot is green.
+
+## Architecture
+
+### Update mechanism — switch to a push model
+
+The original plugin-health-status design committed to a pull-on-`aboutToShow` model: `_populate_main_menu` reads each plugin's `health()` when the user opens the menu. That's still correct for menu rendering, but it cannot drive the tray icon — the icon must update whenever any plugin's health changes, even if the menu is closed.
+
+Add `health_changed = Signal()` on `BaseWidget` (no payload — receivers call `plugin.health()` to read the current value). The signal fires on every transition that changes the visible health:
+
+- `_set_health` emits the signal when the new `HealthReport` differs from `self._current_health` (skips emission on no-op writes to avoid spurious icon repaints).
+- `set_enabled` emits the signal whenever `_is_enabled` actually flips. The toggle changes what `health()` returns (DISABLED vs `_current_health`) without going through `_set_health`, so without this the tray icon would go stale on Plugin enable/disable. The existing early-return guard at the top of `set_enabled` (`if self._is_enabled == enabled: return`) ensures the emit only happens on genuine transitions.
+
+`TrayWidget.__init__` connects each plugin's `health_changed` to a slot that:
+1. Computes `aggregate_health(...)` over the current per-plugin reports.
+2. Builds a new `QIcon` via `tray_icon_for_state(worst_state)` and calls `self._tray_icon.setIcon(...)`.
+
+The slot also fires once during `__init__` (after `self._tray_icon` is set up) so the icon reflects the starting state without waiting for the first transition.
+
+The menu's pull-on-`aboutToShow` path is unchanged. It happily reads the same `_current_health` attribute the signal-driven slot just refreshed; the two paths converge.
+
+### Icon overlay
+
+A new helper in `src/ui/health_icons.py`:
+
+```python
+@cache
+def tray_icon_for_state(state: HealthState) -> QIcon:
+    """Return the tray icon overlaid with a coloured dot for `state`."""
+```
+
+- Base: `QIcon(":/icons/coat-of-arms.ico").pixmap(64, 64)` — render at 64×64; Windows downsamples for the systray slot.
+- Overlay: filled antialiased circle, no pen, fill = `_COLORS[state]`. Diameter 24 px (≈ 38 % of edge). Top-right anchor: bounding box at `(40, 0)` to `(64, 24)`.
+- Compose: paint the base pixmap, then the overlay, into a fresh `QPixmap(64, 64)`. Wrap in a `QIcon` registered for both Normal and Disabled modes (matches the existing `icon_for_state` policy — defensive in case the systray ever exposes the icon as disabled).
+- `@cache` keeps the icon stable across invocations (4 cached entries — one per `HealthState`).
+
+The DISABLED colour is never produced as an aggregate (worst-state ignores DISABLED), but the helper still handles it for API symmetry and to keep the cache key space simple.
+
+## Components
+
+- **`src/base/base_widget.py`** — adds `health_changed = Signal()`. Emits from `_set_health` when the report actually changed, and from `set_enabled` when `_is_enabled` actually flips.
+- **`src/ui/health_icons.py`** — adds `tray_icon_for_state(state)` next to the existing `icon_for_state(state)`.
+- **`src/ui/tray_widget.py`** — connects each plugin's signal in `__init__`, adds a `_refresh_tray_icon()` slot, calls it once at the end of `__init__`.
+
+## Data flow
+
+```
+plugin async event
+    └── plugin._set_health(state, message)
+              ├── self._current_health = HealthReport(...)
+              └── self.health_changed.emit()         (only if value changed)
+                          │
+                          └── TrayWidget._refresh_tray_icon()
+                                     ├── aggregate_health([p.health() for p in child_components])
+                                     └── self._tray_icon.setIcon(tray_icon_for_state(worst_state))
+```
+
+## Error handling
+
+- If `plugin.health()` raises during the slot, the slot catches the exception, logs `logging.exception`, and substitutes `HealthReport(WARNING, "health() failed")` for that plugin — same defensive pattern `_populate_main_menu` already uses.
+- `setIcon` is idempotent; calling it with the same QIcon is a no-op.
+
+## Testing
+
+- `tests/test_base_widget.py` — new tests:
+  - `test_health_changed_emits_on_state_change` — `_set_health(WARNING, "x")` emits exactly once when prior state was OK.
+  - `test_health_changed_emits_on_message_change` — `_set_health(OK, "Manual 60")` after `_set_health(OK, "Auto")` emits.
+  - `test_health_changed_does_not_emit_on_noop` — repeating the same `_set_health` call does not emit.
+  - `test_health_changed_emits_on_set_enabled_transition` — `set_enabled(False)` from an enabled state emits exactly once.
+  - `test_health_changed_does_not_emit_on_set_enabled_noop` — calling `set_enabled` with the current value does not emit.
+- `tests/test_health_icons.py` — new tests:
+  - `test_tray_icon_for_state_returns_non_null` — iterate `HealthState`, assert non-null.
+  - `test_tray_icon_for_state_is_cached` — identity check on repeated calls.
+- `tests/test_tray_widget_health.py` — new test:
+  - `test_tray_icon_refreshes_on_plugin_health_change` — given two stub plugins, fire one's `health_changed` after flipping it to WARNING, assert the tray's `setIcon` was called with the amber-overlay icon. Use a `_TrayForTest` subclass with a stub `_tray_icon` (`MagicMock`) to capture the call.
+
+The plugin signal-emission tests are intentionally on `BaseWidget` rather than per-plugin — every plugin inherits the behaviour, so duplicating tests buys nothing.
+
+## PR scoping
+
+Same PR as the parent feature (#16). The icon overlay is < 80 added lines including tests, and the parent feature is incomplete without it (the user explicitly asked for the indicator after seeing the menu in the smoke run). Follow-up PR would split a unit into two PRs for no benefit.
+
+## Out of scope
+
+- Non-Windows behaviour: the systray on Linux/macOS may render the overlay differently (margins, scaling). The app is Windows-only per `CLAUDE.md`; no cross-platform tuning needed.
+- Per-axis health (e.g. brightness vs contrast as separate dots): the aggregate is one indicator. If a future plugin wants to surface multiple sub-states, it aggregates internally with worst-state-wins and the tray sees one row.
+- Tooltip showing the state on hover: the existing `setToolTip(APP_INFO.APP_NAME)` is unchanged. If the user wants the tooltip to also surface the worst state ("Swiss Windows Knife — 1 warning"), that's a follow-up.
+- Animations / pulses on transitions: a static dot is enough; an animation would draw too much attention.
+
+## Conventional-commits / version impact
+
+This is a `feat:` commit (minor bump): a new user-visible capability building on the same plugin-health-status feature. The `health_changed` signal is internal plumbing for the same feature; ships in the same PR.

--- a/src/base/base_widget.py
+++ b/src/base/base_widget.py
@@ -79,7 +79,7 @@ class BaseWidget(QWidget):
         `_set_health` from inside whatever event path changed their state.
         """
         if self._is_toggleable and not self._is_enabled:
-            return HealthReport(HealthState.DISABLED, "")
+            return HealthReport(HealthState.DISABLED, "Disabled")
         return self._current_health
 
     def _set_health(self, state: HealthState, message: str) -> None:

--- a/src/base/base_widget.py
+++ b/src/base/base_widget.py
@@ -1,5 +1,6 @@
 import logging
 
+from PySide6.QtCore import Signal
 from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QMenu, QWidget
 
@@ -31,6 +32,8 @@ def _coerce_bool(value: object, default: bool) -> bool:
 class BaseWidget(QWidget):
 
     display_name: str = ""
+
+    health_changed = Signal()
 
     def __init__(self, parent: QWidget, is_toggleable: bool = True, is_enabled: bool = True) -> None:
         super().__init__(parent)
@@ -83,4 +86,8 @@ class BaseWidget(QWidget):
         return self._current_health
 
     def _set_health(self, state: HealthState, message: str) -> None:
-        self._current_health = HealthReport(state, message)
+        new_report = HealthReport(state, message)
+        if new_report == self._current_health:
+            return
+        self._current_health = new_report
+        self.health_changed.emit()

--- a/src/base/base_widget.py
+++ b/src/base/base_widget.py
@@ -58,6 +58,7 @@ class BaseWidget(QWidget):
         UserSettings.instance().set(_settings_key(self.__class__), enabled)
         logging.info(f'Plugin {self.__class__.__name__} is enabled: {enabled}')
         self.status_changed(enabled)
+        self.health_changed.emit()
 
     def is_enabled(self) -> bool:
         return self._is_enabled

--- a/src/base/base_widget.py
+++ b/src/base/base_widget.py
@@ -4,6 +4,7 @@ from PySide6.QtGui import QAction
 from PySide6.QtWidgets import QMenu, QWidget
 
 from .config_panel import ConfigPanel
+from .health import HealthReport, HealthState
 from .user_settings import UserSettings
 
 
@@ -42,6 +43,8 @@ class BaseWidget(QWidget):
         else:
             self._is_enabled = is_enabled
 
+        self._current_health: HealthReport = HealthReport(HealthState.OK, "")
+
     def get_display_name(self) -> str:
         return self.display_name or self.__class__.__name__
 
@@ -67,3 +70,17 @@ class BaseWidget(QWidget):
 
     def status_changed(self, status: bool) -> None:
         return None
+
+    def health(self) -> HealthReport:
+        """Return the plugin's current health snapshot.
+
+        MUST be cheap and non-blocking — no I/O, no DDC calls, no socket
+        reads. Subclasses do not override this; instead they call
+        `_set_health` from inside whatever event path changed their state.
+        """
+        if self._is_toggleable and not self._is_enabled:
+            return HealthReport(HealthState.DISABLED, "")
+        return self._current_health
+
+    def _set_health(self, state: HealthState, message: str) -> None:
+        self._current_health = HealthReport(state, message)

--- a/src/base/health.py
+++ b/src/base/health.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class HealthState(StrEnum):
+    OK = "ok"
+    WARNING = "warning"
+    ERROR = "error"
+    DISABLED = "disabled"
+
+
+@dataclass(frozen=True)
+class HealthReport:
+    state: HealthState
+    message: str

--- a/src/components/update_checker.py
+++ b/src/components/update_checker.py
@@ -10,6 +10,7 @@ from PySide6.QtWidgets import QCheckBox, QMenu, QMessageBox, QWidget
 
 from ..app_info import APP_INFO
 from ..base.base_widget import BaseWidget
+from ..base.health import HealthState
 from ..base.user_settings import UserSettings
 
 LATEST_RELEASE_URL = 'https://api.github.com/repos/dbtdsilva/swiss-windows-knife/releases/latest'
@@ -116,6 +117,8 @@ class UpdateChecker(BaseWidget):
         self._check_action: QAction | None = None
         self._active_thread: QThread | None = None
 
+        self._set_health(HealthState.OK, "Checking…")
+
         self.timer = QTimer(self)
         self.timer.timeout.connect(self.check_updates)
         self.timer.start(CHECK_INTERVAL_MS)
@@ -164,6 +167,7 @@ class UpdateChecker(BaseWidget):
         if self._check_action is not None:
             self._check_action.setText(CHECK_LABEL_IDLE)
         self._set_busy(False)
+        self._set_health(HealthState.WARNING, "Check timed out")
         if self._interactive:
             QMessageBox.warning(
                 self, 'Update check timed out',
@@ -186,6 +190,7 @@ class UpdateChecker(BaseWidget):
                 QMessageBox.warning(
                     self, 'Update check failed',
                     'Could not check for updates. See logs for details.')
+            self._set_health(HealthState.WARNING, "Check failed")
             self._set_busy(False)
             return
         remote_version, installer_url = result
@@ -195,10 +200,12 @@ class UpdateChecker(BaseWidget):
                 QMessageBox.information(
                     self, 'No update available',
                     f'You are on the latest version ({APP_INFO.APP_VERSION}).')
+            self._set_health(HealthState.OK, "Up to date")
             self._set_busy(False)
             return
 
         logging.info(f'Update available: {APP_INFO.APP_VERSION} -> {remote_version}')
+        self._set_health(HealthState.OK, f"Update available {remote_version}")
         if not self._confirm_update(remote_version):
             self._set_busy(False)
             return

--- a/src/plugins/device_display_mapper/device_display_mapper_plugin.py
+++ b/src/plugins/device_display_mapper/device_display_mapper_plugin.py
@@ -10,6 +10,7 @@ from PySide6.QtWidgets import QMenu, QWidget
 from ...base.base_widget import BaseWidget
 from ...base.cancellation import Token
 from ...base.config_panel import ConfigPanel
+from ...base.health import HealthState
 from ...base.monitor_runner import runner
 from ...base.user_settings import UserSettings
 from .device_listener import Device, DeviceListener, DeviceNotificationType
@@ -49,7 +50,12 @@ class DeviceDisplayMapperPlugin(BaseWidget):
     def _start_runtime(self) -> None:
         """Spin up the USB watcher and warm caches. Idempotent."""
         if self.device_listener is None:
-            self.device_listener = DeviceListener(self)
+            try:
+                self.device_listener = DeviceListener(self)
+            except Exception as e:
+                logging.exception("Failed to start device listener")
+                self._set_health(HealthState.ERROR, str(e))
+                return
             self.device_listener.change_detected.connect(self.device_changed)
         # Pre-warm both caches in the background so the first time the user
         # opens Configuration the panel populates instantly. Both calls
@@ -58,6 +64,7 @@ class DeviceDisplayMapperPlugin(BaseWidget):
         # cache. No-op callback because no live receiver is interested yet.
         runner().submit(self._prewarm_monitor_cache)
         self.request_usb_devices(lambda _devices: None)
+        self._set_health(HealthState.OK, "Listening")
 
     def _stop_runtime(self) -> None:
         """Tear down the USB watcher. Pre-warmed caches stay (harmless)."""

--- a/src/plugins/display_image_tuner/image_tuner_plugin.py
+++ b/src/plugins/display_image_tuner/image_tuner_plugin.py
@@ -9,6 +9,7 @@ from PySide6.QtWidgets import QMenu, QWidget
 
 from ...base.base_widget import BaseWidget
 from ...base.config_panel import ConfigPanel
+from ...base.health import HealthState
 from ...base.monitor_runner import runner
 from ...base.user_settings import UserSettings
 from .curve import compute_keyframe_value
@@ -44,10 +45,18 @@ class DisplayImageTunerPlugin(BaseWidget):
         self.brightness_changed.connect(self.change_monitor_brightness)
         self.contrast_changed.connect(self.change_monitor_contrast)
 
+        self._set_health(HealthState.OK, self._mode_message())
+
         self._tick_timer = QTimer(self)
         self._tick_timer.timeout.connect(self._tick)
         if self.is_enabled():
             self._tick_timer.start(TICK_MS)
+
+    def _mode_message(self) -> str:
+        b = self.user_settings.get('brightness')
+        if b is None:
+            return "Auto"
+        return f"Manual {b}"
 
     def _seed_default_settings(self) -> None:
         defaults: dict[str, object] = {
@@ -144,8 +153,10 @@ class DisplayImageTunerPlugin(BaseWidget):
                     if monitor.get_luminance() != brightness:
                         monitor.set_luminance(brightness)
                         logging.info(f"Setting brightness to {brightness} on monitor {i}")
+            self._set_health(HealthState.OK, self._mode_message())
         except (ValueError, monitorcontrol.VCPError) as e:
             logging.warning(f"Exception was caught while changing brightness: {e}")
+            self._set_health(HealthState.WARNING, f"Monitor error: {e}")
 
     def change_monitor_contrast(self, contrast):
         runner().submit(self._apply_contrast, contrast)
@@ -157,8 +168,10 @@ class DisplayImageTunerPlugin(BaseWidget):
                     if monitor.get_contrast() != contrast:
                         monitor.set_contrast(contrast)
                         logging.info(f"Setting contrast to {contrast} on monitor {i}")
+            self._set_health(HealthState.OK, self._mode_message())
         except (ValueError, monitorcontrol.VCPError) as e:
             logging.warning(f"Exception was caught while changing contrast: {e}")
+            self._set_health(HealthState.WARNING, f"Monitor error: {e}")
 
     def create_value_control_menu(self, title, property_get, manual_slot, automatic_slot) -> QMenu:
         menu = QMenu(title, self)
@@ -187,15 +200,21 @@ class DisplayImageTunerPlugin(BaseWidget):
     def change_brightness_automatic(self, is_checked):
         if is_checked:
             self.user_settings.set('brightness', None)
+            if self._current_health.state is HealthState.OK:
+                self._set_health(HealthState.OK, self._mode_message())
 
     def change_contrast_automatic(self, is_checked):
         if is_checked:
             self.user_settings.set('contrast', None)
+            if self._current_health.state is HealthState.OK:
+                self._set_health(HealthState.OK, self._mode_message())
 
     def change_brightness_manual(self, is_checked, brightness_level):
         if not is_checked:
             return
         self.user_settings.set('brightness', brightness_level)
+        if self._current_health.state is HealthState.OK:
+            self._set_health(HealthState.OK, self._mode_message())
         self._last_emitted['brightness'] = brightness_level
         self.brightness_changed.emit(brightness_level)
 
@@ -203,6 +222,8 @@ class DisplayImageTunerPlugin(BaseWidget):
         if not is_checked:
             return
         self.user_settings.set('contrast', contrast_level)
+        if self._current_health.state is HealthState.OK:
+            self._set_health(HealthState.OK, self._mode_message())
         self._last_emitted['contrast'] = contrast_level
         self.contrast_changed.emit(contrast_level)
 

--- a/src/plugins/home_assistant_mqtt_pub/home_assistant_mqtt_pub_plugin.py
+++ b/src/plugins/home_assistant_mqtt_pub/home_assistant_mqtt_pub_plugin.py
@@ -6,6 +6,7 @@ from PySide6.QtWidgets import QMenu, QWidget
 
 from ...base.base_widget import BaseWidget
 from ...base.config_panel import ConfigPanel
+from ...base.health import HealthState
 from ...base.user_settings import UserSettings
 from .commands import build_command_registry
 from .device_context import DeviceContext
@@ -34,7 +35,10 @@ class HomeAssistantMqttPubPlugin(BaseWidget):
         cfg = MqttConfig.load_from_settings(self._user_settings)
         self.is_homeassistant_configured = cfg.is_complete()
         if self.is_homeassistant_configured:
+            self._set_health(HealthState.WARNING, "Connecting…")
             self._start_session(cfg)
+        else:
+            self._set_health(HealthState.WARNING, "Not configured")
 
     def _start_session(self, cfg: MqttConfig) -> None:
         ctx = DeviceContext(name=str(cfg.device_name))
@@ -55,10 +59,14 @@ class HomeAssistantMqttPubPlugin(BaseWidget):
                 lambda payload, c=command: c.run(),
             )
         self._session.on_connected = self._dispatch_on_connected
+        self._session.on_disconnected = self._dispatch_on_disconnected
         self._session.start()
 
     def _dispatch_on_connected(self) -> None:
         QMetaObject.invokeMethod(self, "_run_on_connected", Qt.ConnectionType.QueuedConnection)
+
+    def _dispatch_on_disconnected(self) -> None:
+        QMetaObject.invokeMethod(self, "_run_on_disconnected", Qt.ConnectionType.QueuedConnection)
 
     def _dispatch_ha_status(self, payload: str) -> None:
         QMetaObject.invokeMethod(
@@ -68,8 +76,13 @@ class HomeAssistantMqttPubPlugin(BaseWidget):
 
     @Slot()
     def _run_on_connected(self) -> None:
+        self._set_health(HealthState.OK, "Connected")
         if self._publisher is not None:
             self._publisher.on_connected()
+
+    @Slot()
+    def _run_on_disconnected(self) -> None:
+        self._set_health(HealthState.WARNING, "Disconnected")
 
     @Slot(str)
     def _run_on_ha_status(self, payload: str) -> None:
@@ -80,6 +93,7 @@ class HomeAssistantMqttPubPlugin(BaseWidget):
     def status_changed(self, status: bool) -> None:
         if status and self._session is None and self.is_homeassistant_configured:
             cfg = MqttConfig.load_from_settings(self._user_settings)
+            self._set_health(HealthState.WARNING, "Connecting…")
             self._start_session(cfg)
         elif not status and self._publisher is not None and self._session is not None:
             try:
@@ -92,11 +106,7 @@ class HomeAssistantMqttPubPlugin(BaseWidget):
 
     @override
     def retrieve_menus(self) -> list[QMenu | QAction]:
-        menu = QMenu("Home Assistant", self)
-        configured = QAction("Configured" if self.is_homeassistant_configured else "Not configured", self)
-        configured.setEnabled(False)
-        menu.addAction(configured)
-        return [menu]
+        return []
 
     @override
     def retrieve_config_panels(self) -> list[ConfigPanel]:
@@ -114,7 +124,10 @@ class HomeAssistantMqttPubPlugin(BaseWidget):
         cfg = MqttConfig.load_from_settings(self._user_settings)
         self.is_homeassistant_configured = cfg.is_complete()
         if self.is_homeassistant_configured and self.is_enabled():
+            self._set_health(HealthState.WARNING, "Connecting…")
             self._start_session(cfg)
+        elif not self.is_homeassistant_configured:
+            self._set_health(HealthState.WARNING, "Not configured")
 
     def closeEvent(self, event):
         if self._publisher is not None:

--- a/src/plugins/home_assistant_mqtt_pub/mqtt_session.py
+++ b/src/plugins/home_assistant_mqtt_pub/mqtt_session.py
@@ -28,6 +28,7 @@ class MqttSession:
         self._client.on_message = self._on_message
 
         self.on_connected: Callable[[], None] | None = None
+        self.on_disconnected: Callable[[], None] | None = None
 
     def subscribe(self, topic: str, handler: Callable[[str], None]) -> None:
         """Register a handler for the topic.
@@ -72,6 +73,11 @@ class MqttSession:
 
     def _on_disconnect(self, client, userdata, flags, rc, properties):
         logging.info("MQTT disconnected rc=%s", rc)
+        if self.on_disconnected is not None:
+            try:
+                self.on_disconnected()
+            except Exception:
+                logging.exception("on_disconnected hook raised")
 
     def _on_message(self, client, userdata, msg):
         handler = self._handlers.get(msg.topic)

--- a/src/swiss_windows_knife.py
+++ b/src/swiss_windows_knife.py
@@ -85,4 +85,4 @@ class SwissWindowsKnife:
 
 
 if __name__ == '__main__':
-    SwissWindowsKnife()
+    SwissWindowsKnife(dev_mode=not getattr(sys, 'frozen', False))

--- a/src/ui/health_icons.py
+++ b/src/ui/health_icons.py
@@ -27,4 +27,10 @@ def icon_for_state(state: HealthState) -> QIcon:
         painter.drawEllipse(0, 0, _ICON_SIZE.width(), _ICON_SIZE.height())
     finally:
         painter.end()
-    return QIcon(pix)
+    icon = QIcon()
+    # Health rows and the summary line are disabled QActions, so Qt would
+    # auto-grey a single-mode icon. Register the coloured pixmap for both
+    # Normal and Disabled modes so the dot keeps its colour either way.
+    icon.addPixmap(pix, QIcon.Mode.Normal)
+    icon.addPixmap(pix, QIcon.Mode.Disabled)
+    return icon

--- a/src/ui/health_icons.py
+++ b/src/ui/health_icons.py
@@ -14,6 +14,9 @@ _COLORS: dict[HealthState, QColor] = {
 
 _ICON_SIZE = QSize(12, 12)
 
+_TRAY_ICON_SIZE = QSize(64, 64)
+_TRAY_DOT_RECT = (40, 0, 24, 24)  # x, y, width, height — top-right
+
 
 @cache
 def icon_for_state(state: HealthState) -> QIcon:
@@ -33,4 +36,29 @@ def icon_for_state(state: HealthState) -> QIcon:
     # Normal and Disabled modes so the dot keeps its colour either way.
     icon.addPixmap(pix, QIcon.Mode.Normal)
     icon.addPixmap(pix, QIcon.Mode.Disabled)
+    return icon
+
+
+@cache
+def tray_icon_for_state(state: HealthState) -> QIcon:
+    """Return the app's tray icon overlaid with a coloured dot for `state`.
+
+    The dot sits in the top-right corner of a 64x64 composed pixmap;
+    Windows downsamples for the systray slot. Cached per state.
+    """
+    base = QIcon(":/icons/coat-of-arms.ico").pixmap(_TRAY_ICON_SIZE)
+    composed = QPixmap(_TRAY_ICON_SIZE)
+    composed.fill(Qt.GlobalColor.transparent)
+    painter = QPainter(composed)
+    try:
+        painter.drawPixmap(0, 0, base)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        painter.setBrush(_COLORS[state])
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.drawEllipse(*_TRAY_DOT_RECT)
+    finally:
+        painter.end()
+    icon = QIcon()
+    icon.addPixmap(composed, QIcon.Mode.Normal)
+    icon.addPixmap(composed, QIcon.Mode.Disabled)
     return icon

--- a/src/ui/health_icons.py
+++ b/src/ui/health_icons.py
@@ -1,0 +1,30 @@
+from functools import cache
+
+from PySide6.QtCore import QSize, Qt
+from PySide6.QtGui import QColor, QIcon, QPainter, QPixmap
+
+from ..base.health import HealthState
+
+_COLORS: dict[HealthState, QColor] = {
+    HealthState.OK: QColor(76, 175, 80),       # green
+    HealthState.WARNING: QColor(255, 152, 0),  # amber
+    HealthState.ERROR: QColor(244, 67, 54),    # red
+    HealthState.DISABLED: QColor(158, 158, 158),  # grey
+}
+
+_ICON_SIZE = QSize(12, 12)
+
+
+@cache
+def icon_for_state(state: HealthState) -> QIcon:
+    pix = QPixmap(_ICON_SIZE)
+    pix.fill(Qt.GlobalColor.transparent)
+    painter = QPainter(pix)
+    try:
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing, True)
+        painter.setBrush(_COLORS[state])
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.drawEllipse(0, 0, _ICON_SIZE.width(), _ICON_SIZE.height())
+    finally:
+        painter.end()
+    return QIcon(pix)

--- a/src/ui/health_icons.py
+++ b/src/ui/health_icons.py
@@ -15,7 +15,7 @@ _COLORS: dict[HealthState, QColor] = {
 _ICON_SIZE = QSize(12, 12)
 
 _TRAY_ICON_SIZE = QSize(64, 64)
-_TRAY_DOT_RECT = (40, 0, 24, 24)  # x, y, width, height — top-right
+_TRAY_DOT_RECT = (40, 40, 24, 24)  # x, y, width, height — bottom-right
 
 
 @cache
@@ -43,7 +43,7 @@ def icon_for_state(state: HealthState) -> QIcon:
 def tray_icon_for_state(state: HealthState) -> QIcon:
     """Return the app's tray icon overlaid with a coloured dot for `state`.
 
-    The dot sits in the top-right corner of a 64x64 composed pixmap;
+    The dot sits in the bottom-right corner of a 64x64 composed pixmap;
     Windows downsamples for the systray slot. Cached per state.
     """
     base = QIcon(":/icons/coat-of-arms.ico").pixmap(_TRAY_ICON_SIZE)

--- a/src/ui/tray_widget.py
+++ b/src/ui/tray_widget.py
@@ -85,12 +85,8 @@ class TrayWidget(QWidget):
                 reports.append((plugin, HealthReport(HealthState.WARNING, "health() failed")))
 
         worst_state, summary_text = aggregate_health([r for _, r in reports])
-        summary_action = QAction(summary_text, self)
-        summary_action.setIcon(icon_for_state(worst_state))
-        summary_action.setEnabled(False)
-        menu.addAction(summary_action)
-
-        health_submenu = QMenu("Health", menu)
+        health_submenu = QMenu(summary_text, menu)
+        health_submenu.setIcon(icon_for_state(worst_state))
         for plugin, report in reports:
             row = QAction(f"{plugin.get_display_name()} — {report.message}", self)
             row.setIcon(icon_for_state(report.state))

--- a/src/ui/tray_widget.py
+++ b/src/ui/tray_widget.py
@@ -15,7 +15,7 @@ from ..plugins.display_image_tuner.image_tuner_plugin import DisplayImageTunerPl
 from ..plugins.home_assistant_mqtt_pub.home_assistant_mqtt_pub_plugin import HomeAssistantMqttPubPlugin
 from .about_dialog import AboutDialog
 from .configuration_dialog import ConfigurationDialog
-from .health_icons import icon_for_state
+from .health_icons import icon_for_state, tray_icon_for_state
 from .tray_logger import TrayLogger
 
 
@@ -67,11 +67,29 @@ class TrayWidget(QWidget):
         self._tray_icon.setToolTip(APP_INFO.APP_NAME)
         self._tray_icon.setIcon(QIcon(":/icons/coat-of-arms.ico"))
         self._tray_icon.show()
+        self._wire_health_signals()
+        self._refresh_tray_icon()
 
     def createMainMenu(self) -> QMenu:
         menu = QMenu(self)
         menu.aboutToShow.connect(lambda m=menu: self._populate_main_menu(m))
         return menu
+
+    def _wire_health_signals(self) -> None:
+        for plugin in self.child_components:
+            plugin.health_changed.connect(self._refresh_tray_icon)
+
+    @Slot()
+    def _refresh_tray_icon(self) -> None:
+        reports: list[HealthReport] = []
+        for plugin in self.child_components:
+            try:
+                reports.append(plugin.health())
+            except Exception:
+                logging.exception("plugin %s health() raised", plugin.__class__.__name__)
+                reports.append(HealthReport(HealthState.WARNING, "health() failed"))
+        worst_state, _ = aggregate_health(reports)
+        self._tray_icon.setIcon(tray_icon_for_state(worst_state))
 
     def _populate_main_menu(self, menu: QMenu) -> None:
         menu.clear()

--- a/src/ui/tray_widget.py
+++ b/src/ui/tray_widget.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 
 from PySide6.QtCore import QCoreApplication, QObject, Slot
@@ -7,13 +8,31 @@ from PySide6.QtWidgets import QMenu, QMessageBox, QSystemTrayIcon, QWidget
 from .. import resources  # noqa: F401,E261
 from ..app_info import APP_INFO
 from ..base.base_widget import BaseWidget
+from ..base.health import HealthReport, HealthState
 from ..components.update_checker import UpdateChecker
 from ..plugins.device_display_mapper.device_display_mapper_plugin import DeviceDisplayMapperPlugin
 from ..plugins.display_image_tuner.image_tuner_plugin import DisplayImageTunerPlugin
 from ..plugins.home_assistant_mqtt_pub.home_assistant_mqtt_pub_plugin import HomeAssistantMqttPubPlugin
 from .about_dialog import AboutDialog
 from .configuration_dialog import ConfigurationDialog
+from .health_icons import icon_for_state
 from .tray_logger import TrayLogger
+
+
+def aggregate_health(reports: list[HealthReport]) -> tuple[HealthState, str]:
+    """Compute (worst-state, summary-text) for the tray top line.
+
+    Reports in DISABLED state are ignored entirely. When no plugins are
+    in WARNING or ERROR, the summary is "Health: All OK"; otherwise it's
+    "Health: N warning(s), M error(s)".
+    """
+    n_warning = sum(1 for r in reports if r.state is HealthState.WARNING)
+    n_error = sum(1 for r in reports if r.state is HealthState.ERROR)
+    if n_error > 0:
+        return HealthState.ERROR, f"Health: {n_warning} warning(s), {n_error} error(s)"
+    if n_warning > 0:
+        return HealthState.WARNING, f"Health: {n_warning} warning(s), {n_error} error(s)"
+    return HealthState.OK, "Health: All OK"
 
 
 class TrayWidget(QWidget):
@@ -57,7 +76,30 @@ class TrayWidget(QWidget):
     def _populate_main_menu(self, menu: QMenu) -> None:
         menu.clear()
 
+        reports: list[tuple[BaseWidget, HealthReport]] = []
         for plugin in self.child_components:
+            try:
+                reports.append((plugin, plugin.health()))
+            except Exception:
+                logging.exception("plugin %s health() raised", plugin.__class__.__name__)
+                reports.append((plugin, HealthReport(HealthState.WARNING, "health() failed")))
+
+        worst_state, summary_text = aggregate_health([r for _, r in reports])
+        summary_action = QAction(summary_text, self)
+        summary_action.setIcon(icon_for_state(worst_state))
+        summary_action.setEnabled(False)
+        menu.addAction(summary_action)
+
+        health_submenu = QMenu("Health", menu)
+        for plugin, report in reports:
+            row = QAction(f"{plugin.get_display_name()} — {report.message}", self)
+            row.setIcon(icon_for_state(report.state))
+            row.setEnabled(False)
+            health_submenu.addAction(row)
+        menu.addMenu(health_submenu)
+        menu.addSeparator()
+
+        for plugin, _ in reports:
             if plugin.is_toggleable() and not plugin.is_enabled():
                 continue
             for action in plugin.retrieve_menus():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,33 @@
+import os
+
 import pytest
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_unconfigure(config):
+    """Side-step a QtWebEngine teardown segfault on Windows + offscreen Qt.
+
+    `LocationPickerWidget` instantiates a `QWebEngineView` whose default
+    profile keeps a reference to the page beyond pytest's own teardown.
+    When the interpreter then unwinds the QtWebEngine globals, the
+    profile's destructor logs `Release of profile requested but
+    WebEnginePage still not deleted` and segfaults — exit code 1 on CI
+    despite every test passing. `pytest_unconfigure` runs after the
+    terminal summary has already been written and flushed, so we can
+    force an immediate exit and skip Qt's interpreter-shutdown unwinding.
+    """
+    import sys
+    sys.stdout.flush()
+    sys.stderr.flush()
+    if getattr(config, "_test_session_exit_status", 0) == 0:
+        os._exit(0)
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_sessionfinish(session, exitstatus):
+    # Stash exitstatus where pytest_unconfigure can read it. We can't call
+    # os._exit here because the terminal summary hasn't been flushed yet.
+    session.config._test_session_exit_status = exitstatus
 
 
 class _FakeUserSettings:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,11 @@ class _FakePahoClient:
         m.timestamp = 0
         self.on_message(self, None, m)
 
+    def fire_on_disconnect(self, rc=0):
+        self.connected = False
+        if self.on_disconnect is not None:
+            self.on_disconnect(self, None, None, rc, None)
+
 
 @pytest.fixture
 def fake_paho_client(monkeypatch):

--- a/tests/test_base_widget.py
+++ b/tests/test_base_widget.py
@@ -178,3 +178,25 @@ def test_health_changed_does_not_emit_on_noop(qtbot, fake_user_settings):
 
     widget._set_health(HealthState.OK, "Auto")  # same value
     assert fired == []
+
+
+def test_health_changed_emits_on_set_enabled_transition(qtbot, fake_user_settings):
+    widget = BaseWidget(None, is_toggleable=True, is_enabled=True)
+    qtbot.addWidget(widget)
+
+    fired: list[None] = []
+    widget.health_changed.connect(lambda: fired.append(None))
+
+    widget.set_enabled(False)
+    assert fired == [None]
+
+
+def test_health_changed_does_not_emit_on_set_enabled_noop(qtbot, fake_user_settings):
+    widget = BaseWidget(None, is_toggleable=True, is_enabled=True)
+    qtbot.addWidget(widget)
+
+    fired: list[None] = []
+    widget.health_changed.connect(lambda: fired.append(None))
+
+    widget.set_enabled(True)  # already True
+    assert fired == []

--- a/tests/test_base_widget.py
+++ b/tests/test_base_widget.py
@@ -109,3 +109,34 @@ def test_set_enabled_no_change_does_not_invoke_status_changed(qtbot, fake_user_s
 
     w.set_enabled(False)
     assert w.calls == [False]
+
+
+def test_health_defaults_to_ok_with_empty_message(qtbot, fake_user_settings):
+    from src.base.health import HealthReport, HealthState
+    widget = BaseWidget(None)
+    qtbot.addWidget(widget)
+    assert widget.health() == HealthReport(HealthState.OK, "")
+
+
+def test_set_health_updates_current_health(qtbot, fake_user_settings):
+    from src.base.health import HealthReport, HealthState
+    widget = BaseWidget(None)
+    qtbot.addWidget(widget)
+    widget._set_health(HealthState.WARNING, "broker down")
+    assert widget.health() == HealthReport(HealthState.WARNING, "broker down")
+
+
+def test_health_returns_disabled_for_toggleable_off(qtbot, fake_user_settings):
+    from src.base.health import HealthReport, HealthState
+    widget = BaseWidget(None, is_toggleable=True, is_enabled=False)
+    qtbot.addWidget(widget)
+    widget._set_health(HealthState.WARNING, "ignored while off")
+    assert widget.health() == HealthReport(HealthState.DISABLED, "")
+
+
+def test_health_ignores_is_enabled_for_non_toggleable_widget(qtbot, fake_user_settings):
+    from src.base.health import HealthReport, HealthState
+    widget = BaseWidget(None, is_toggleable=False, is_enabled=False)
+    qtbot.addWidget(widget)
+    widget._set_health(HealthState.OK, "running")
+    assert widget.health() == HealthReport(HealthState.OK, "running")

--- a/tests/test_base_widget.py
+++ b/tests/test_base_widget.py
@@ -140,3 +140,41 @@ def test_health_ignores_is_enabled_for_non_toggleable_widget(qtbot, fake_user_se
     qtbot.addWidget(widget)
     widget._set_health(HealthState.OK, "running")
     assert widget.health() == HealthReport(HealthState.OK, "running")
+
+
+def test_health_changed_emits_on_state_change(qtbot, fake_user_settings):
+    from src.base.health import HealthState
+    widget = BaseWidget(None)
+    qtbot.addWidget(widget)
+
+    fired: list[None] = []
+    widget.health_changed.connect(lambda: fired.append(None))
+
+    widget._set_health(HealthState.WARNING, "x")
+    assert fired == [None]
+
+
+def test_health_changed_emits_on_message_change(qtbot, fake_user_settings):
+    from src.base.health import HealthState
+    widget = BaseWidget(None)
+    qtbot.addWidget(widget)
+    widget._set_health(HealthState.OK, "Auto")
+
+    fired: list[None] = []
+    widget.health_changed.connect(lambda: fired.append(None))
+
+    widget._set_health(HealthState.OK, "Manual 60")
+    assert fired == [None]
+
+
+def test_health_changed_does_not_emit_on_noop(qtbot, fake_user_settings):
+    from src.base.health import HealthState
+    widget = BaseWidget(None)
+    qtbot.addWidget(widget)
+    widget._set_health(HealthState.OK, "Auto")
+
+    fired: list[None] = []
+    widget.health_changed.connect(lambda: fired.append(None))
+
+    widget._set_health(HealthState.OK, "Auto")  # same value
+    assert fired == []

--- a/tests/test_base_widget.py
+++ b/tests/test_base_widget.py
@@ -131,7 +131,7 @@ def test_health_returns_disabled_for_toggleable_off(qtbot, fake_user_settings):
     widget = BaseWidget(None, is_toggleable=True, is_enabled=False)
     qtbot.addWidget(widget)
     widget._set_health(HealthState.WARNING, "ignored while off")
-    assert widget.health() == HealthReport(HealthState.DISABLED, "")
+    assert widget.health() == HealthReport(HealthState.DISABLED, "Disabled")
 
 
 def test_health_ignores_is_enabled_for_non_toggleable_widget(qtbot, fake_user_settings):

--- a/tests/test_device_display_mapper_health.py
+++ b/tests/test_device_display_mapper_health.py
@@ -1,0 +1,71 @@
+import pytest
+
+from src.base.health import HealthState
+
+
+class _FakeDeviceListener:
+    instances: list = []
+
+    def __init__(self, parent):
+        self.closed = False
+
+        class _Sig:
+            def connect(self, *_args, **_kwargs):
+                pass
+
+        self.change_detected = _Sig()
+        _FakeDeviceListener.instances.append(self)
+
+    def close(self):
+        self.closed = True
+
+
+class _ExplodingListener:
+    def __init__(self, parent):
+        raise RuntimeError("WMI unavailable")
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    _FakeDeviceListener.instances.clear()
+    yield
+    _FakeDeviceListener.instances.clear()
+
+
+def _patch(monkeypatch, listener_cls):
+    monkeypatch.setattr(
+        "src.plugins.device_display_mapper.device_display_mapper_plugin.DeviceListener",
+        listener_cls,
+    )
+    monkeypatch.setattr(
+        "src.plugins.device_display_mapper.device_display_mapper_plugin."
+        "DeviceDisplayMapperPlugin._prewarm_monitor_cache",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        "src.plugins.device_display_mapper.device_display_mapper_plugin."
+        "DeviceDisplayMapperPlugin.request_usb_devices",
+        lambda self, cb: None,
+    )
+
+
+def test_health_is_ok_listening_on_successful_start(qtbot, fake_user_settings, monkeypatch):
+    _patch(monkeypatch, _FakeDeviceListener)
+    from src.plugins.device_display_mapper.device_display_mapper_plugin import (
+        DeviceDisplayMapperPlugin,
+    )
+    p = DeviceDisplayMapperPlugin(None)
+    qtbot.addWidget(p)
+    assert p.health().state is HealthState.OK
+    assert p.health().message == "Listening"
+
+
+def test_health_is_error_when_listener_construction_fails(qtbot, fake_user_settings, monkeypatch):
+    _patch(monkeypatch, _ExplodingListener)
+    from src.plugins.device_display_mapper.device_display_mapper_plugin import (
+        DeviceDisplayMapperPlugin,
+    )
+    p = DeviceDisplayMapperPlugin(None)
+    qtbot.addWidget(p)
+    assert p.health().state is HealthState.ERROR
+    assert "WMI unavailable" in p.health().message

--- a/tests/test_display_image_tuner_health.py
+++ b/tests/test_display_image_tuner_health.py
@@ -1,0 +1,56 @@
+from unittest.mock import MagicMock, patch
+
+import monitorcontrol
+import pytest
+
+from src.base.health import HealthState
+
+
+@pytest.fixture
+def plugin(qtbot, fake_user_settings):
+    from src.plugins.display_image_tuner.image_tuner_plugin import DisplayImageTunerPlugin
+    p = DisplayImageTunerPlugin(None)
+    qtbot.addWidget(p)
+    return p
+
+
+def test_initial_health_is_ok_auto(plugin):
+    report = plugin.health()
+    assert report.state is HealthState.OK
+    assert report.message == "Auto"
+
+
+def test_health_message_reflects_manual_brightness(qtbot, fake_user_settings):
+    fake_user_settings.set("brightness", 60)
+    from src.plugins.display_image_tuner.image_tuner_plugin import DisplayImageTunerPlugin
+    p = DisplayImageTunerPlugin(None)
+    qtbot.addWidget(p)
+    assert p.health().message == "Manual 60"
+
+
+def _stub_monitor(value: int):
+    cm = MagicMock()
+    cm.__enter__ = lambda self: self
+    cm.__exit__ = lambda self, exc_type, exc, tb: None
+    cm.get_luminance = MagicMock(return_value=value)
+    cm.set_luminance = MagicMock()
+    cm.get_contrast = MagicMock(return_value=value)
+    cm.set_contrast = MagicMock()
+    return cm
+
+
+def test_apply_brightness_failure_sets_warning(plugin):
+    with patch("monitorcontrol.get_monitors", side_effect=monitorcontrol.VCPError("boom")):
+        plugin._apply_brightness(50)
+    assert plugin.health().state is HealthState.WARNING
+    assert "Monitor error" in plugin.health().message
+
+
+def test_apply_brightness_success_restores_ok(plugin):
+    with patch("monitorcontrol.get_monitors", side_effect=monitorcontrol.VCPError("boom")):
+        plugin._apply_brightness(50)
+    assert plugin.health().state is HealthState.WARNING
+
+    with patch("monitorcontrol.get_monitors", return_value=[_stub_monitor(0)]):
+        plugin._apply_brightness(50)
+    assert plugin.health().state is HealthState.OK

--- a/tests/test_ha_plugin_health.py
+++ b/tests/test_ha_plugin_health.py
@@ -1,0 +1,61 @@
+import pytest
+
+from src.base.health import HealthState
+
+
+@pytest.fixture
+def configured_settings(fake_user_settings):
+    fake_user_settings.set("homeassistant_host", "broker")
+    fake_user_settings.set("homeassistant_port", 1883)
+    fake_user_settings.set("homeassistant_username", "u")
+    fake_user_settings.set("homeassistant_password", "p")
+    fake_user_settings.set("homeassistant_client_id", "cid")
+    fake_user_settings.set("homeassistant_device_name", "TestPC")
+    return fake_user_settings
+
+
+def _make_plugin(qtbot):
+    from src.plugins.home_assistant_mqtt_pub.home_assistant_mqtt_pub_plugin import (
+        HomeAssistantMqttPubPlugin,
+    )
+    plugin = HomeAssistantMqttPubPlugin(parent=None)
+    qtbot.addWidget(plugin)
+    return plugin
+
+
+def test_health_is_warning_not_configured_when_no_config(qtbot, fake_user_settings, fake_paho_client):
+    plugin = _make_plugin(qtbot)
+    report = plugin.health()
+    assert report.state is HealthState.WARNING
+    assert report.message == "Not configured"
+
+
+def test_health_is_warning_connecting_after_session_starts(qtbot, configured_settings, fake_paho_client):
+    plugin = _make_plugin(qtbot)
+    report = plugin.health()
+    assert report.state is HealthState.WARNING
+    assert report.message == "Connecting…"
+
+
+def test_health_is_ok_connected_after_on_connect(qtbot, configured_settings, fake_paho_client):
+    plugin = _make_plugin(qtbot)
+    fake_paho_client[0].fire_on_connect(rc=0)
+    qtbot.wait(20)  # cross to GUI thread via QMetaObject.invokeMethod
+    report = plugin.health()
+    assert report.state is HealthState.OK
+    assert report.message == "Connected"
+
+
+def test_health_returns_to_warning_after_disconnect(qtbot, configured_settings, fake_paho_client):
+    plugin = _make_plugin(qtbot)
+    fake_paho_client[0].fire_on_connect(rc=0)
+    fake_paho_client[0].fire_on_disconnect(rc=0)
+    qtbot.wait(20)  # cross to GUI thread via QMetaObject.invokeMethod
+    report = plugin.health()
+    assert report.state is HealthState.WARNING
+    assert report.message == "Disconnected"
+
+
+def test_retrieve_menus_no_longer_returns_status_submenu(qtbot, configured_settings, fake_paho_client):
+    plugin = _make_plugin(qtbot)
+    assert plugin.retrieve_menus() == []

--- a/tests/test_ha_session.py
+++ b/tests/test_ha_session.py
@@ -63,3 +63,24 @@ def test_stop_publishes_offline_then_disconnects(fake_paho_client):
     assert ("homeassistant/swk_pc/availability", "offline", True) in client.published
     assert client.loop_started is False
     assert client.connected is False
+
+
+def test_on_disconnect_fires_callback(fake_paho_client):
+    sess = MqttSession(broker_config=_broker(), availability_topic=_ctx().availability_topic)
+    fired: list[bool] = []
+    sess.on_disconnected = lambda: fired.append(True)
+    sess.start()
+    fake_paho_client[0].fire_on_connect(rc=0)
+    fake_paho_client[0].fire_on_disconnect(rc=0)
+    assert fired == [True]
+
+
+def test_on_disconnect_callback_exceptions_are_swallowed(fake_paho_client):
+    sess = MqttSession(broker_config=_broker(), availability_topic=_ctx().availability_topic)
+
+    def boom():
+        raise RuntimeError("ignored")
+
+    sess.on_disconnected = boom
+    sess.start()
+    fake_paho_client[0].fire_on_disconnect(rc=0)  # must not raise

--- a/tests/test_health_icons.py
+++ b/tests/test_health_icons.py
@@ -15,3 +15,22 @@ def test_icon_is_cached_per_state(qtbot):
     a = icon_for_state(HealthState.OK)
     b = icon_for_state(HealthState.OK)
     assert a is b
+
+
+def test_tray_icon_for_state_returns_non_null(qtbot):
+    # Resources must be loaded so :/icons/coat-of-arms.ico resolves.
+    from src import resources  # noqa: F401
+    from src.ui.health_icons import tray_icon_for_state
+
+    for state in HealthState:
+        icon = tray_icon_for_state(state)
+        assert not icon.isNull(), f"tray icon for {state} is null"
+
+
+def test_tray_icon_for_state_is_cached(qtbot):
+    from src import resources  # noqa: F401
+    from src.ui.health_icons import tray_icon_for_state
+
+    a = tray_icon_for_state(HealthState.OK)
+    b = tray_icon_for_state(HealthState.OK)
+    assert a is b

--- a/tests/test_health_icons.py
+++ b/tests/test_health_icons.py
@@ -1,0 +1,17 @@
+from src.base.health import HealthState
+
+
+def test_icon_for_state_returns_qicon(qtbot):
+    from src.ui.health_icons import icon_for_state
+
+    for state in HealthState:
+        icon = icon_for_state(state)
+        assert not icon.isNull(), f"icon for {state} is null"
+
+
+def test_icon_is_cached_per_state(qtbot):
+    from src.ui.health_icons import icon_for_state
+
+    a = icon_for_state(HealthState.OK)
+    b = icon_for_state(HealthState.OK)
+    assert a is b

--- a/tests/test_health_types.py
+++ b/tests/test_health_types.py
@@ -1,0 +1,19 @@
+import pytest
+
+from src.base.health import HealthReport, HealthState
+
+
+def test_health_state_has_four_values():
+    assert {s.value for s in HealthState} == {"ok", "warning", "error", "disabled"}
+
+
+def test_health_report_holds_state_and_message():
+    r = HealthReport(HealthState.OK, "Connected")
+    assert r.state is HealthState.OK
+    assert r.message == "Connected"
+
+
+def test_health_report_is_frozen():
+    r = HealthReport(HealthState.OK, "Connected")
+    with pytest.raises((AttributeError, Exception)):
+        r.message = "Other"

--- a/tests/test_tray_widget_health.py
+++ b/tests/test_tray_widget_health.py
@@ -1,0 +1,148 @@
+import pytest
+
+from src.base.health import HealthReport, HealthState
+
+
+def test_aggregate_health_all_ok():
+    from src.ui.tray_widget import aggregate_health
+
+    reports = [HealthReport(HealthState.OK, ""), HealthReport(HealthState.OK, "")]
+    state, text = aggregate_health(reports)
+    assert state is HealthState.OK
+    assert text == "Health: All OK"
+
+
+def test_aggregate_health_disabled_does_not_contribute():
+    from src.ui.tray_widget import aggregate_health
+
+    reports = [HealthReport(HealthState.OK, ""), HealthReport(HealthState.DISABLED, "")]
+    state, text = aggregate_health(reports)
+    assert state is HealthState.OK
+    assert text == "Health: All OK"
+
+
+def test_aggregate_health_warning_count():
+    from src.ui.tray_widget import aggregate_health
+
+    reports = [
+        HealthReport(HealthState.OK, ""),
+        HealthReport(HealthState.WARNING, "x"),
+        HealthReport(HealthState.WARNING, "y"),
+    ]
+    state, text = aggregate_health(reports)
+    assert state is HealthState.WARNING
+    assert text == "Health: 2 warning(s), 0 error(s)"
+
+
+def test_aggregate_health_error_outranks_warning():
+    from src.ui.tray_widget import aggregate_health
+
+    reports = [
+        HealthReport(HealthState.WARNING, ""),
+        HealthReport(HealthState.ERROR, ""),
+    ]
+    state, text = aggregate_health(reports)
+    assert state is HealthState.ERROR
+    assert text == "Health: 1 warning(s), 1 error(s)"
+
+
+class _StubPlugin:
+    def __init__(self, name: str, report: HealthReport):
+        self._name = name
+        self._report = report
+
+    def get_display_name(self):
+        return self._name
+
+    def is_toggleable(self):
+        return True
+
+    def is_enabled(self):
+        return self._report.state is not HealthState.DISABLED
+
+    def health(self):
+        return self._report
+
+    def retrieve_menus(self):
+        return []
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def tray_with_stubs(qtbot, fake_user_settings):
+    """Build a TrayWidget-like instance backed by a real QWidget so QAction
+    parenting works, but skipping the real plugin construction and the
+    QSystemTrayIcon side-effects."""
+    from PySide6.QtWidgets import QWidget
+
+    from src.ui.tray_widget import TrayWidget
+
+    class _TrayForTest(TrayWidget):
+        def __init__(self, stubs):
+            QWidget.__init__(self, parent=None)
+            self._config_dialog = None
+            self.logger_window = None
+            self.child_components = stubs
+
+    def _make(stubs):
+        tray = _TrayForTest(stubs)
+        qtbot.addWidget(tray)
+        return tray
+
+    return _make
+
+
+def test_main_menu_starts_with_summary_and_health_submenu(qtbot, tray_with_stubs):
+    plugins = [
+        _StubPlugin("Alpha", HealthReport(HealthState.OK, "Auto")),
+        _StubPlugin("Bravo", HealthReport(HealthState.WARNING, "Disconnected")),
+    ]
+    tray = tray_with_stubs(plugins)
+
+    from PySide6.QtWidgets import QMenu
+    menu = QMenu()
+    tray._populate_main_menu(menu)
+    actions = menu.actions()
+
+    assert actions[0].text() == "Health: 1 warning(s), 0 error(s)"
+    assert actions[0].isEnabled() is False  # summary line is informational
+
+    health_submenu = actions[1].menu()
+    assert health_submenu is not None
+    rows = [a.text() for a in health_submenu.actions()]
+    assert rows == ["Alpha — Auto", "Bravo — Disconnected"]
+
+
+def test_main_menu_summary_all_ok_when_only_disabled_remain(qtbot, tray_with_stubs):
+    plugins = [
+        _StubPlugin("Alpha", HealthReport(HealthState.DISABLED, "")),
+        _StubPlugin("Bravo", HealthReport(HealthState.OK, "Listening")),
+    ]
+    tray = tray_with_stubs(plugins)
+
+    from PySide6.QtWidgets import QMenu
+    menu = QMenu()
+    tray._populate_main_menu(menu)
+    assert menu.actions()[0].text() == "Health: All OK"
+
+
+def test_health_row_for_failing_plugin_does_not_break_menu(qtbot, tray_with_stubs):
+    class _Bad(_StubPlugin):
+        def health(self):
+            raise RuntimeError("boom")
+
+    plugins = [
+        _Bad("Bad", HealthReport(HealthState.OK, "")),
+        _StubPlugin("Good", HealthReport(HealthState.OK, "ok")),
+    ]
+    tray = tray_with_stubs(plugins)
+
+    from PySide6.QtWidgets import QMenu
+    menu = QMenu()
+    tray._populate_main_menu(menu)
+    health_submenu = menu.actions()[1].menu()
+    rows = [a.text() for a in health_submenu.actions()]
+    assert rows[0] == "Bad — health() failed"
+    assert rows[1] == "Good — ok"

--- a/tests/test_tray_widget_health.py
+++ b/tests/test_tray_widget_health.py
@@ -147,3 +147,68 @@ def test_health_row_for_failing_plugin_does_not_break_menu(qtbot, tray_with_stub
     rows = [a.text() for a in health_submenu.actions()]
     assert rows[0] == "Bad — health() failed"
     assert rows[1] == "Good — ok"
+
+
+def test_tray_icon_refreshes_on_plugin_health_change(qtbot, fake_user_settings):
+    """The tray's icon refresh slot is wired to each plugin's health_changed
+    signal and rebuilds the icon via tray_icon_for_state."""
+    from unittest.mock import MagicMock
+
+    from PySide6.QtCore import Signal
+    from PySide6.QtWidgets import QWidget
+
+    from src import resources  # noqa: F401
+    from src.base.health import HealthState
+    from src.ui.tray_widget import TrayWidget
+
+    class _SignalingPlugin(QWidget):
+        health_changed = Signal()
+
+        def __init__(self, name: str, report: HealthReport):
+            super().__init__()
+            self._name = name
+            self._report = report
+
+        def get_display_name(self):
+            return self._name
+
+        def is_toggleable(self):
+            return True
+
+        def is_enabled(self):
+            return self._report.state is not HealthState.DISABLED
+
+        def health(self):
+            return self._report
+
+        def retrieve_menus(self):
+            return []
+
+        def set_report(self, report: HealthReport) -> None:
+            self._report = report
+            self.health_changed.emit()
+
+    plugins = [
+        _SignalingPlugin("Alpha", HealthReport(HealthState.OK, "ok")),
+        _SignalingPlugin("Bravo", HealthReport(HealthState.OK, "ok")),
+    ]
+
+    class _TrayForTest(TrayWidget):
+        def __init__(self, components):
+            QWidget.__init__(self, parent=None)
+            self._config_dialog = None
+            self.logger_window = None
+            self.child_components = components
+            self._tray_icon = MagicMock()
+            self._wire_health_signals()
+            self._refresh_tray_icon()
+
+    tray = _TrayForTest(plugins)
+    qtbot.addWidget(tray)
+
+    # Initial refresh in __init__ called setIcon once with the OK icon.
+    assert tray._tray_icon.setIcon.call_count == 1
+
+    tray._tray_icon.setIcon.reset_mock()
+    plugins[1].set_report(HealthReport(HealthState.WARNING, "broker down"))
+    assert tray._tray_icon.setIcon.call_count == 1

--- a/tests/test_tray_widget_health.py
+++ b/tests/test_tray_widget_health.py
@@ -94,7 +94,7 @@ def tray_with_stubs(qtbot, fake_user_settings):
     return _make
 
 
-def test_main_menu_starts_with_summary_and_health_submenu(qtbot, tray_with_stubs):
+def test_main_menu_first_entry_is_health_submenu_with_summary_title(qtbot, tray_with_stubs):
     plugins = [
         _StubPlugin("Alpha", HealthReport(HealthState.OK, "Auto")),
         _StubPlugin("Bravo", HealthReport(HealthState.WARNING, "Disconnected")),
@@ -104,13 +104,10 @@ def test_main_menu_starts_with_summary_and_health_submenu(qtbot, tray_with_stubs
     from PySide6.QtWidgets import QMenu
     menu = QMenu()
     tray._populate_main_menu(menu)
-    actions = menu.actions()
 
-    assert actions[0].text() == "Health: 1 warning(s), 0 error(s)"
-    assert actions[0].isEnabled() is False  # summary line is informational
-
-    health_submenu = actions[1].menu()
+    health_submenu = menu.actions()[0].menu()
     assert health_submenu is not None
+    assert health_submenu.title() == "Health: 1 warning(s), 0 error(s)"
     rows = [a.text() for a in health_submenu.actions()]
     assert rows == ["Alpha — Auto", "Bravo — Disconnected"]
 
@@ -125,9 +122,9 @@ def test_main_menu_summary_all_ok_when_only_disabled_remain(qtbot, tray_with_stu
     from PySide6.QtWidgets import QMenu
     menu = QMenu()
     tray._populate_main_menu(menu)
-    assert menu.actions()[0].text() == "Health: All OK"
 
-    health_submenu = menu.actions()[1].menu()
+    health_submenu = menu.actions()[0].menu()
+    assert health_submenu.title() == "Health: All OK"
     rows = [a.text() for a in health_submenu.actions()]
     assert rows == ["Alpha — Disabled", "Bravo — Listening"]
 
@@ -146,7 +143,7 @@ def test_health_row_for_failing_plugin_does_not_break_menu(qtbot, tray_with_stub
     from PySide6.QtWidgets import QMenu
     menu = QMenu()
     tray._populate_main_menu(menu)
-    health_submenu = menu.actions()[1].menu()
+    health_submenu = menu.actions()[0].menu()
     rows = [a.text() for a in health_submenu.actions()]
     assert rows[0] == "Bad — health() failed"
     assert rows[1] == "Good — ok"

--- a/tests/test_tray_widget_health.py
+++ b/tests/test_tray_widget_health.py
@@ -117,7 +117,7 @@ def test_main_menu_starts_with_summary_and_health_submenu(qtbot, tray_with_stubs
 
 def test_main_menu_summary_all_ok_when_only_disabled_remain(qtbot, tray_with_stubs):
     plugins = [
-        _StubPlugin("Alpha", HealthReport(HealthState.DISABLED, "")),
+        _StubPlugin("Alpha", HealthReport(HealthState.DISABLED, "Disabled")),
         _StubPlugin("Bravo", HealthReport(HealthState.OK, "Listening")),
     ]
     tray = tray_with_stubs(plugins)
@@ -126,6 +126,10 @@ def test_main_menu_summary_all_ok_when_only_disabled_remain(qtbot, tray_with_stu
     menu = QMenu()
     tray._populate_main_menu(menu)
     assert menu.actions()[0].text() == "Health: All OK"
+
+    health_submenu = menu.actions()[1].menu()
+    rows = [a.text() for a in health_submenu.actions()]
+    assert rows == ["Alpha — Disabled", "Bravo — Listening"]
 
 
 def test_health_row_for_failing_plugin_does_not_break_menu(qtbot, tray_with_stubs):

--- a/tests/test_update_checker_health.py
+++ b/tests/test_update_checker_health.py
@@ -1,0 +1,57 @@
+from unittest.mock import patch
+
+import pytest
+
+from src.base.health import HealthState
+
+
+@pytest.fixture
+def checker(qtbot, fake_user_settings):
+    from src.components.update_checker import UpdateChecker
+    with patch.object(UpdateChecker, "check_updates"):
+        c = UpdateChecker(parent=None)
+        qtbot.addWidget(c)
+    return c
+
+
+def test_initial_health_is_ok_checking(checker):
+    assert checker.health().state is HealthState.OK
+    assert checker.health().message == "Checking…"
+
+
+def test_health_warning_when_check_returns_none(checker):
+    checker._busy = True
+    checker._on_check_finished(None)
+    assert checker.health().state is HealthState.WARNING
+    assert checker.health().message == "Check failed"
+
+
+def test_health_warning_when_watchdog_fires(checker):
+    checker._set_busy(True)
+    checker._interactive = False
+    checker._check_watchdog()
+    assert checker.health().state is HealthState.WARNING
+    assert checker.health().message == "Check timed out"
+
+
+def test_health_ok_up_to_date_when_remote_version_not_newer(checker):
+    checker._busy = True
+    with patch("src.components.update_checker.APP_INFO") as app_info:
+        app_info.APP_VERSION = "1.0.0"
+        checker._on_check_finished(("1.0.0", "https://example/installer.exe"))
+    assert checker.health().state is HealthState.OK
+    assert checker.health().message == "Up to date"
+
+
+def test_health_ok_update_available_when_remote_newer(qtbot, fake_user_settings):
+    from src.components.update_checker import UpdateChecker
+    with patch.object(UpdateChecker, "check_updates"):
+        c = UpdateChecker(parent=None)
+        qtbot.addWidget(c)
+    c._busy = True
+    with patch("src.components.update_checker.APP_INFO") as app_info, \
+         patch.object(c, "_confirm_update", return_value=False):
+        app_info.APP_VERSION = "1.0.0"
+        c._on_check_finished(("9.9.9", "https://example/installer.exe"))
+    assert c.health().state is HealthState.OK
+    assert c.health().message == "Update available 9.9.9"


### PR DESCRIPTION
## Summary

- New `Health: …` submenu at the top of the tray with worst-state aggregation (`Health: All OK` / `Health: N warning(s), M error(s)` with a green / amber / red dot) and a row per plugin (`<plugin> — <message>`, coloured dot per state). Replaces HA's old `Configured / Not configured` submenu.
- Per-plugin states wired from inside existing event paths: HA (`Not configured` / `Connecting…` / `Connected` / `Disconnected`), Display brightness (`Auto` / `Manual N` / `Monitor error: …`), USB display switch (`Listening` / listener-construction error), Auto-updater (`Checking…` / `Up to date` / `Update available vN` / `Check failed` / `Check timed out`). Toggleable plugins flipped off short-circuit to `Disabled` regardless of their cached state.
- Drive-by: dev runs (`python -m src.swiss_windows_knife`) now auto-detect via `sys.frozen` and skip the auto-updater so the tray no longer announces "Update available …" while iterating on the next version.

## Test plan

- [ ] `./env/Scripts/python.exe -m pytest tests/ -q` is green (222 passing locally on this branch).
- [ ] `./env/Scripts/python.exe -m ruff check src tests` is clean.
- [ ] Launch the dev tray and confirm:
  - [ ] Top entry reads `Health: All OK` with a green dot when nothing is misbehaving.
  - [ ] Each plugin appears in the submenu with the right colour and message.
  - [ ] Toggling a plugin off in `Configuration → Plugins` flips it to a grey `Disabled` row.
  - [ ] Briefly disconnecting from the network flips the HA row to `Disconnected` (amber) and back to `Connected` (green) on reconnect.
  - [ ] The dev tray no longer creates the update-checker (no `Spawning update-check worker` log line and no `Auto-updater` row in the Health submenu when running from source).