### PR TITLE
Fix configuration-dialog tab toggle crash + crash diagnostics

### DIFF
--- a/swiss_windows_knife/__main__.py
+++ b/swiss_windows_knife/__main__.py
@@ -2,9 +2,12 @@ import ctypes
 import faulthandler
 import inspect
 import logging
+import os
 import signal
 import sys
 import traceback
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
 
 from PySide6.QtGui import QIcon
 from PySide6.QtWidgets import QApplication
@@ -34,13 +37,7 @@ def _set_windows_app_user_model_id() -> None:
 class SwissWindowsKnife:
 
     def __init__(self, dev_mode: bool = False) -> None:
-        self.init_logging()
-        # Native crashes print a C-stack to stderr — but cx_Freeze with
-        # `base='Win32GUI'` builds the frozen exe without a console, so
-        # `sys.stderr` is None and `faulthandler.enable()` raises
-        # `RuntimeError: sys.stderr is None`. Skip it in that case.
-        if sys.stderr is not None:
-            faulthandler.enable()
+        self.init_diagnostics()
 
         signal.signal(signal.SIGINT, signal.SIG_DFL)
         _set_windows_app_user_model_id()
@@ -63,7 +60,22 @@ class SwissWindowsKnife:
         tb = "".join(traceback.format_exception(exc_type, exc_value, exc_tb))
         logging.error("Unhandled exception: \n%s", tb)
 
-    def init_logging(self):
+    def init_diagnostics(self) -> None:
+        local_appdata = os.environ.get('LOCALAPPDATA')
+        base = Path(local_appdata) if local_appdata else Path.home() / 'AppData' / 'Local'
+        logs_dir = base / APP_INFO.APP_NAME / 'logs'
+        logs_dir.mkdir(parents=True, exist_ok=True)
+
+        # Route faulthandler to a file because Win32GUI cx_Freeze builds have
+        # `sys.stderr is None`; otherwise native crashes (Qt stack overflows,
+        # ctypes segfaults) leave only a one-line Windows Event Log entry.
+        # The handle is stored on self so the fd outlives this method.
+        self._fault_log = open(logs_dir / 'faulthandler.log', 'ab', buffering=0)
+        faulthandler.enable(file=self._fault_log, all_threads=True)
+
+        self.init_logging(logs_dir)
+
+    def init_logging(self, logs_dir: Path) -> None:
         class LoggingModuleNameFilter(logging.Filter):
             def filter(self, record):
                 frame = inspect.currentframe()
@@ -79,11 +91,26 @@ class SwissWindowsKnife:
                     frame = frame.f_back
                 return True
 
-        handler = logging.StreamHandler(sys.stdout)
-        handler.addFilter(LoggingModuleNameFilter())
+        module_name_filter = LoggingModuleNameFilter()
+        handlers: list[logging.Handler] = []
+
+        file_handler = RotatingFileHandler(
+            logs_dir / 'swiss-windows-knife.log',
+            maxBytes=5_000_000, backupCount=3, encoding='utf-8',
+        )
+        file_handler.addFilter(module_name_filter)
+        handlers.append(file_handler)
+
+        # Skip StreamHandler when stdout is None (Win32GUI frozen build) —
+        # it would silently swallow every record.
+        if sys.stdout is not None:
+            stream_handler = logging.StreamHandler(sys.stdout)
+            stream_handler.addFilter(module_name_filter)
+            handlers.append(stream_handler)
+
         logging.basicConfig(format='[%(asctime)s %(name)s-%(threadName)s %(levelname)s] %(message)s',
                             level=logging.INFO,
-                            handlers=[handler])
+                            handlers=handlers)
 
 
 if __name__ == '__main__':

--- a/swiss_windows_knife/ui/configuration_dialog.py
+++ b/swiss_windows_knife/ui/configuration_dialog.py
@@ -27,8 +27,9 @@ class ConfigurationDialog(PersistentSizeDialog):
 
         # `_panels_by_plugin` is the persistent record of "which panels does
         # this plugin contribute" (queried once at construction). `_tab_index`
-        # tracks which of those are currently inserted in the QTabWidget so
-        # we can show/hide them as the user toggles checkboxes.
+        # maps each panel to its tab position in the QTabWidget; every panel
+        # is inserted once at construction and toggled via `setTabVisible`,
+        # so the index stays valid for the dialog's lifetime.
         self._panels_by_plugin: dict = {}
         self._tab_index: dict = {}
 
@@ -47,9 +48,10 @@ class ConfigurationDialog(PersistentSizeDialog):
         for plugin in self._plugins:
             panels = list(plugin.retrieve_config_panels())
             self._panels_by_plugin[plugin] = panels
-            if plugin.is_enabled():
-                for panel in panels:
-                    self._insert_plugin_panel(plugin, panel)
+            for panel in panels:
+                self._insert_plugin_panel(plugin, panel)
+            if not plugin.is_enabled():
+                self._set_plugin_tabs_visible(plugin, False)
 
         buttons = QDialogButtonBox(
             QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel,
@@ -107,21 +109,14 @@ class ConfigurationDialog(PersistentSizeDialog):
         self._tabs.insertTab(insert_at, self._wrap_in_scroll(panel), title)
         self._rebuild_tab_index()
 
-    def _remove_plugin_panel(self, panel: ConfigPanel) -> None:
-        index = self._tab_index.pop(panel, None)
-        if index is None:
-            return
-        self._tabs.removeTab(index)
-        self._rebuild_tab_index()
+    def _set_plugin_tabs_visible(self, plugin, visible: bool) -> None:
+        for panel in self._panels_by_plugin.get(plugin, []):
+            index = self._tab_index.get(panel)
+            if index is not None:
+                self._tabs.setTabVisible(index, visible)
 
     def _on_plugin_toggled(self, plugin, enabled: bool) -> None:
-        panels = self._panels_by_plugin.get(plugin, [])
-        if enabled:
-            for panel in panels:
-                self._insert_plugin_panel(plugin, panel)
-        else:
-            for panel in panels:
-                self._remove_plugin_panel(panel)
+        self._set_plugin_tabs_visible(plugin, enabled)
 
     def _on_accept(self) -> None:
         for panel in self._all_panels:

--- a/tests/test_configuration_dialog.py
+++ b/tests/test_configuration_dialog.py
@@ -49,6 +49,10 @@ def _reset():
     _FakePlugin.instances.clear()
 
 
+def _visible_tab_titles(tabs) -> list[str]:
+    return [tabs.tabText(i) for i in range(tabs.count()) if tabs.isTabVisible(i)]
+
+
 @pytest.fixture
 def make_dialog(qtbot, fake_user_settings):
     from swiss_windows_knife.ui.configuration_dialog import ConfigurationDialog
@@ -73,8 +77,7 @@ def test_disabled_plugin_panels_are_hidden_initially(make_dialog):
     enabled = _FakePlugin("E", True, [_NamedPanel("EPanel")])
     disabled = _FakePlugin("D", False, [_NamedPanel("DPanel")])
     dlg = make_dialog([enabled, disabled])
-    titles = [dlg._tabs.tabText(i) for i in range(dlg._tabs.count())]
-    assert titles == ["General", "EPanel"]
+    assert _visible_tab_titles(dlg._tabs) == ["General", "EPanel"]
 
 
 def test_enabling_via_general_panel_inserts_tab(make_dialog):
@@ -84,8 +87,7 @@ def test_enabling_via_general_panel_inserts_tab(make_dialog):
     general_panel = dlg._general_panel
     general_panel._checkboxes[disabled].setChecked(True)
 
-    titles = [dlg._tabs.tabText(i) for i in range(dlg._tabs.count())]
-    assert "DPanel" in titles
+    assert "DPanel" in _visible_tab_titles(dlg._tabs)
 
 
 def test_disabling_via_general_panel_removes_tab(make_dialog):
@@ -94,28 +96,24 @@ def test_disabling_via_general_panel_removes_tab(make_dialog):
     general_panel = dlg._general_panel
     general_panel._checkboxes[enabled].setChecked(False)
 
-    titles = [dlg._tabs.tabText(i) for i in range(dlg._tabs.count())]
-    assert "EPanel" not in titles
+    assert "EPanel" not in _visible_tab_titles(dlg._tabs)
 
 
 def test_per_plugin_tabs_render_in_alphabetical_order(make_dialog):
     p1 = _FakePlugin("Whatever", True, [_NamedPanel("Zeta")])
     p2 = _FakePlugin("Whatever", True, [_NamedPanel("Alpha"), _NamedPanel("Mu")])
     dlg = make_dialog([p1, p2])
-    titles = [dlg._tabs.tabText(i) for i in range(dlg._tabs.count())]
-    assert titles == ["General", "Alpha", "Mu", "Zeta"]
+    assert _visible_tab_titles(dlg._tabs) == ["General", "Alpha", "Mu", "Zeta"]
 
 
 def test_enabling_inserts_tab_at_alphabetical_position(make_dialog):
     enabled = _FakePlugin("E", True, [_NamedPanel("Beta"), _NamedPanel("Yankee")])
     disabled = _FakePlugin("D", False, [_NamedPanel("Mike")])
     dlg = make_dialog([enabled, disabled])
-    assert [dlg._tabs.tabText(i) for i in range(dlg._tabs.count())] == [
-        "General", "Beta", "Yankee",
-    ]
+    assert _visible_tab_titles(dlg._tabs) == ["General", "Beta", "Yankee"]
 
     dlg._general_panel._checkboxes[disabled].setChecked(True)
-    assert [dlg._tabs.tabText(i) for i in range(dlg._tabs.count())] == [
+    assert _visible_tab_titles(dlg._tabs) == [
         "General", "Beta", "Mike", "Yankee",
     ]
 

--- a/tools/setup_wer_dumps.ps1
+++ b/tools/setup_wer_dumps.ps1
@@ -1,0 +1,23 @@
+# Enable Windows Error Reporting LocalDumps for SwissWindowsKnife.exe so the
+# next native crash (Qt stack overflow, segfault, etc.) leaves a full minidump
+# under %LOCALAPPDATA%\CrashDumps that can be opened in WinDbg. The LocalDumps
+# key lives in HKLM, so this script must run elevated. Idempotent.
+
+#Requires -RunAsAdministrator
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$exeKey = 'HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps\SwissWindowsKnife.exe'
+$dumpDir = '%LOCALAPPDATA%\CrashDumps'
+
+if (-not (Test-Path $exeKey)) {
+    New-Item -Path $exeKey -Force | Out-Null
+}
+New-ItemProperty -Path $exeKey -Name DumpFolder -PropertyType ExpandString -Value $dumpDir -Force | Out-Null
+New-ItemProperty -Path $exeKey -Name DumpCount  -PropertyType DWord        -Value 5        -Force | Out-Null
+New-ItemProperty -Path $exeKey -Name DumpType   -PropertyType DWord        -Value 2        -Force | Out-Null
+
+$expanded = [Environment]::ExpandEnvironmentVariables($dumpDir)
+Write-Host "Configured WER LocalDumps for SwissWindowsKnife.exe." -ForegroundColor Green
+Write-Host "Future crash dumps will land in: $expanded"


### PR DESCRIPTION
## Summary

- **fix**: Toggling a plugin in the Configuration dialog used to `removeTab` + `insertTab` with a freshly-built `QScrollArea` each time, leaving the previous scroll's event filter installed on the panel. After one off/on cycle the panel had two filters bouncing `Resize`/`LayoutRequest` events at each other, and Qt's layout engine recursed until the GUI stack overflowed during the next GC pass (\`Qt6Widgets.dll\`, exception \`0xc00000fd\`). Panels are now inserted once at construction and toggled via \`QTabWidget.setTabVisible\`.
- **chore**: Crash diagnostics. \`faulthandler\` is now pinned to \`%LOCALAPPDATA%\Swiss Windows Knife\logs\faulthandler.log\` unconditionally (the Win32GUI cx_Freeze build has \`sys.stderr is None\` so the previous conditional \`faulthandler.enable()\` was a no-op there). A \`RotatingFileHandler\` writes the existing logging stream to disk so \`logging.*\` and \`excepthook\` output survives. \`StreamHandler\` is only attached when \`sys.stdout\` is not None (it silently swallowed every record in the frozen build). \`tools/setup_wer_dumps.ps1\` is a one-shot elevated helper that configures WER LocalDumps for \`SwissWindowsKnife.exe\`.

## Test plan

- [x] \`pytest tests/test_configuration_dialog.py\` — 7/7 pass (assertions filter by \`isTabVisible\`)
- [x] \`ruff check\` — clean
- [x] Synthetic crash repro: 20 rounds of plugin off/on + HA↔Display tab switching with forced \`gc.collect\` survives end-to-end; pre-fix it crashed in round 1
- [x] Manual: open Configuration, toggle plugins on/off, switch tabs — no crash
- [x] Optional: run \`tools/setup_wer_dumps.ps1\` from elevated PowerShell to enable WER LocalDumps for future native faults