### PR TITLE
fix: retry auto brightness/contrast after VCP error

### DIFF
--- a/swiss_windows_knife/plugins/display_image_tuner/image_tuner_plugin.py
+++ b/swiss_windows_knife/plugins/display_image_tuner/image_tuner_plugin.py
@@ -149,6 +149,9 @@ class DisplayImageTunerPlugin(BaseWidget):
             self._set_health(HealthState.OK, self._mode_message())
         except (ValueError, monitorcontrol.VCPError) as e:
             logging.warning(f"Exception was caught while changing brightness: {e}")
+            # Clear the dedup cache so _tick re-emits next tick; otherwise a
+            # transient VCP error leaves the monitor at its old value forever.
+            self._last_emitted['brightness'] = None
             self._set_health(HealthState.WARNING, f"Monitor error: {e}")
 
     def change_monitor_contrast(self, contrast):
@@ -164,6 +167,7 @@ class DisplayImageTunerPlugin(BaseWidget):
             self._set_health(HealthState.OK, self._mode_message())
         except (ValueError, monitorcontrol.VCPError) as e:
             logging.warning(f"Exception was caught while changing contrast: {e}")
+            self._last_emitted['contrast'] = None
             self._set_health(HealthState.WARNING, f"Monitor error: {e}")
 
     def create_value_control_menu(self, title, axis, manual_slot, automatic_slot) -> QMenu:

--- a/tests/test_device_listener.py
+++ b/tests/test_device_listener.py
@@ -1,0 +1,168 @@
+"""Coverage for the WMI device-listener shutdown path.
+
+Tray shutdown depends on `_DeviceListenerThread.run` exiting on
+interruption and unwinding COM, and on `DeviceListener.closeEvent`
+joining both watcher threads. A regression in either manifests as
+"tray won't quit cleanly".
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def _listener_module():
+    import swiss_windows_knife.plugins.device_display_mapper.device_listener as m
+    return m
+
+
+def _run_with_iterations(thread, listener_module, iterations, watcher):
+    """Drive `thread.run()` with a controlled isInterruptionRequested
+    sequence and a mocked wmi + pythoncom environment. Returns the
+    pythoncom mock so callers can assert on Co(Un)Initialize."""
+    # `except wmi.x_wmi_timed_out:` in the source needs the real
+    # exception class; capture it before the patch swaps `wmi` for a Mock.
+    real_x_wmi_timed_out = listener_module.wmi.x_wmi_timed_out
+    fake_wmi = MagicMock()
+    fake_wmi.watch_for.return_value = watcher
+
+    with patch.object(thread, "isInterruptionRequested", side_effect=lambda: next(iterations)), \
+         patch.object(listener_module, "wmi") as mock_wmi_mod, \
+         patch.object(listener_module, "pythoncom") as mock_pythoncom:
+        mock_wmi_mod.x_wmi_timed_out = real_x_wmi_timed_out
+        mock_wmi_mod.WMI.return_value = fake_wmi
+        thread.run()
+        return mock_pythoncom, fake_wmi
+
+
+def test_listener_thread_initializes_com_and_uninitializes_on_interrupt(_listener_module):
+    from swiss_windows_knife.plugins.device_display_mapper.device_listener import (
+        DeviceNotificationType,
+        _DeviceListenerThread,
+    )
+
+    signal = MagicMock()
+    thread = _DeviceListenerThread(
+        parent=None,
+        parent_signal=signal,
+        notification_type=DeviceNotificationType.CREATION,
+    )
+    watcher = MagicMock(side_effect=_listener_module.wmi.x_wmi_timed_out)
+    iterations = iter([False, True])
+
+    pythoncom_mock, fake_wmi = _run_with_iterations(thread, _listener_module, iterations, watcher)
+
+    assert pythoncom_mock.CoInitialize.called
+    assert pythoncom_mock.CoUninitialize.called
+    signal.emit.assert_not_called()
+    fake_wmi.watch_for.assert_called_once_with(
+        notification_type="Creation",
+        wmi_class="Win32_PnPEntity",
+        delay_secs=1,
+    )
+
+
+def test_listener_thread_emits_signal_on_wmi_event(_listener_module):
+    from swiss_windows_knife.plugins.device_display_mapper.device_listener import (
+        Device,
+        DeviceNotificationType,
+        _DeviceListenerThread,
+    )
+
+    signal = MagicMock()
+    thread = _DeviceListenerThread(
+        parent=None,
+        parent_signal=signal,
+        notification_type=DeviceNotificationType.DELETION,
+    )
+    fake_usb = MagicMock(
+        DeviceID="USB\\VID_046D&PID_C534\\1234",
+        Name="USB Receiver",
+        Description="USB Composite Device",
+        Manufacturer="Logitech",
+    )
+    watcher = MagicMock(return_value=fake_usb)
+    iterations = iter([False, True])
+
+    pythoncom_mock, _ = _run_with_iterations(thread, _listener_module, iterations, watcher)
+
+    assert pythoncom_mock.CoUninitialize.called
+    signal.emit.assert_called_once()
+    notif_type, device = signal.emit.call_args.args
+    assert notif_type is DeviceNotificationType.DELETION
+    assert isinstance(device, Device)
+    assert device.id == "USB\\VID_046D&PID_C534\\1234"
+    assert device.name == "USB Receiver"
+    assert device.manufacturer == "Logitech"
+
+
+def test_listener_thread_skips_event_with_bad_attributes(_listener_module):
+    """A WMI event that loses its backing object mid-read raises on
+    attribute access. The loop must log and keep going, not exit."""
+    from swiss_windows_knife.plugins.device_display_mapper.device_listener import (
+        DeviceNotificationType,
+        _DeviceListenerThread,
+    )
+
+    signal = MagicMock()
+    thread = _DeviceListenerThread(
+        parent=None,
+        parent_signal=signal,
+        notification_type=DeviceNotificationType.CREATION,
+    )
+    bad_usb = MagicMock()
+    type(bad_usb).DeviceID = property(lambda self: (_ for _ in ()).throw(RuntimeError("gone")))
+    watcher = MagicMock(return_value=bad_usb)
+    iterations = iter([False, True])
+
+    pythoncom_mock, _ = _run_with_iterations(thread, _listener_module, iterations, watcher)
+
+    assert pythoncom_mock.CoUninitialize.called
+    signal.emit.assert_not_called()
+
+
+def test_close_event_interrupts_and_waits_for_both_listener_threads(qtbot, monkeypatch):
+    fake_threads: list = []
+
+    class _FakeListenerThread:
+        def __init__(self, parent, parent_signal, notification_type):
+            self.notification_type = notification_type
+            self.started = False
+            self.interrupted = False
+            self.waited = False
+            fake_threads.append(self)
+
+        def start(self):
+            self.started = True
+
+        def requestInterruption(self):
+            self.interrupted = True
+
+        def wait(self):
+            self.waited = True
+
+    monkeypatch.setattr(
+        "swiss_windows_knife.plugins.device_display_mapper.device_listener.wmi.WMI",
+        MagicMock(),
+    )
+    monkeypatch.setattr(
+        "swiss_windows_knife.plugins.device_display_mapper.device_listener._DeviceListenerThread",
+        _FakeListenerThread,
+    )
+
+    from swiss_windows_knife.plugins.device_display_mapper.device_listener import DeviceListener
+    listener = DeviceListener(parent=None)
+    qtbot.addWidget(listener)
+
+    assert len(fake_threads) == 2
+    assert all(t.started for t in fake_threads)
+    notif_types = {t.notification_type for t in fake_threads}
+    from swiss_windows_knife.plugins.device_display_mapper.device_listener import DeviceNotificationType
+    assert notif_types == {DeviceNotificationType.CREATION, DeviceNotificationType.DELETION}
+
+    event = MagicMock()
+    listener.closeEvent(event)
+
+    assert all(t.interrupted for t in fake_threads)
+    assert all(t.waited for t in fake_threads)
+    event.accept.assert_called_once()

--- a/tests/test_display_image_tuner_health.py
+++ b/tests/test_display_image_tuner_health.py
@@ -54,3 +54,26 @@ def test_apply_brightness_success_restores_ok(plugin):
     with patch("monitorcontrol.get_monitors", return_value=[_stub_monitor(0)]):
         plugin._apply_brightness(50)
     assert plugin.health().state is HealthState.OK
+
+
+def test_apply_failure_invalidates_last_emitted_so_tick_retries(plugin):
+    # _tick advances _last_emitted before the async runner has tried to
+    # write — if the write fails, the dedup gate must not lock the plugin
+    # at the never-applied value, or auto mode stops updating the monitor.
+    plugin._last_emitted['brightness'] = 50
+    plugin._last_emitted['contrast'] = 70
+    with patch("monitorcontrol.get_monitors", side_effect=monitorcontrol.VCPError("boom")):
+        plugin._apply_brightness(50)
+        plugin._apply_contrast(70)
+    assert plugin._last_emitted['brightness'] is None
+    assert plugin._last_emitted['contrast'] is None
+
+
+def test_apply_success_preserves_last_emitted(plugin):
+    plugin._last_emitted['brightness'] = 50
+    plugin._last_emitted['contrast'] = 70
+    with patch("monitorcontrol.get_monitors", return_value=[_stub_monitor(0)]):
+        plugin._apply_brightness(50)
+        plugin._apply_contrast(70)
+    assert plugin._last_emitted['brightness'] == 50
+    assert plugin._last_emitted['contrast'] == 70

--- a/tests/test_ha_session.py
+++ b/tests/test_ha_session.py
@@ -84,3 +84,42 @@ def test_on_disconnect_callback_exceptions_are_swallowed(fake_paho_client):
     sess.on_disconnected = boom
     sess.start()
     fake_paho_client[0].fire_on_disconnect(rc=0)  # must not raise
+
+
+def test_reconnect_resubscribes_all_topics(fake_paho_client):
+    """Broker bounces are the main real-world failure mode: after a
+    disconnect+reconnect, every previously-registered topic must be
+    re-subscribed (paho drops subscriptions on disconnect)."""
+    sess = MqttSession(broker_config=_broker(), availability_topic=_ctx().availability_topic)
+    sess.subscribe("homeassistant/status", lambda payload: None)
+    sess.subscribe("homeassistant/button/swk_pc/lock/set", lambda payload: None)
+    sess.start()
+    client = fake_paho_client[0]
+
+    client.fire_on_connect(rc=0)
+    assert client.subscribed == [
+        "homeassistant/status",
+        "homeassistant/button/swk_pc/lock/set",
+    ]
+
+    client.subscribed.clear()
+    client.fire_on_disconnect(rc=0)
+    client.fire_on_connect(rc=0)
+
+    assert client.subscribed == [
+        "homeassistant/status",
+        "homeassistant/button/swk_pc/lock/set",
+    ]
+
+
+def test_failed_reconnect_does_not_resubscribe(fake_paho_client):
+    """An on_connect with non-zero rc means the broker rejected us — must
+    not call subscribe() on a non-connected client."""
+    sess = MqttSession(broker_config=_broker(), availability_topic=_ctx().availability_topic)
+    sess.subscribe("homeassistant/status", lambda payload: None)
+    sess.start()
+    client = fake_paho_client[0]
+
+    client.fire_on_connect(rc=5)
+
+    assert client.subscribed == []


### PR DESCRIPTION
## Summary
- Fix the display image tuner getting stuck when a transient `VCPError` interrupts an auto-mode write: `_tick` advanced `_last_emitted` before the async monitor write ran, so a failure locked the dedup gate at a value that never reached the monitor. Cache is now cleared in the apply error path so the next tick retries.
- Adds tests covering the invalidate-on-failure and preserve-on-success paths for both axes.
- Picks up the earlier `test/network-io-coverage` work that covered MQTT reconnect + device-listener shutdown paths.

## Test plan
- [x] `pytest` (306 passed)
- [x] Restarted the tray; brightness reached the auto target on monitors that had been stuck at the pre-error value.