### PR TITLE
feat: re-assert brightness/contrast when displays wake from suspend

### DIFF
--- a/swiss_windows_knife/plugins/display_image_tuner/display_wake_listener.py
+++ b/swiss_windows_knife/plugins/display_image_tuner/display_wake_listener.py
@@ -1,0 +1,139 @@
+"""Display wake / system-resume listener via Win32 WM_POWERBROADCAST.
+
+Fires `woke` when the monitors power back on (DPMS console display state
+off -> on, e.g. the user moves the mouse to wake idle screens) or the
+system resumes from sleep. The display tuner uses it to re-assert
+brightness/contrast, because some monitors reset their DDC luminance to
+the onboard OSD value on a power-cycle while still reporting the old
+value on `get_luminance()`.
+"""
+import ctypes
+import logging
+from ctypes import wintypes
+
+from PySide6 import QtCore
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QWidget
+
+from ...base.base_widget import BaseWidget
+
+WM_POWERBROADCAST = 0x0218
+PBT_APMRESUMESUSPEND = 0x0007
+PBT_APMRESUMEAUTOMATIC = 0x0012
+PBT_POWERSETTINGCHANGE = 0x8013
+DEVICE_NOTIFY_WINDOW_HANDLE = 0x00000000
+
+DISPLAY_STATE_OFF = 0
+DISPLAY_STATE_ON = 1
+DISPLAY_STATE_DIMMED = 2
+
+
+class _GUID(ctypes.Structure):
+    _fields_ = [
+        ("Data1", ctypes.c_ulong),
+        ("Data2", ctypes.c_ushort),
+        ("Data3", ctypes.c_ushort),
+        ("Data4", ctypes.c_ubyte * 8),
+    ]
+
+
+# GUID_CONSOLE_DISPLAY_STATE {6FE69556-704A-47A0-8F24-C28D936FDA47}:
+# monitor DPMS power state; Data is a DWORD (off/on/dimmed).
+GUID_CONSOLE_DISPLAY_STATE = _GUID(
+    0x6FE69556, 0x704A, 0x47A0,
+    (ctypes.c_ubyte * 8)(0x8F, 0x24, 0xC2, 0x8D, 0x93, 0x6F, 0xDA, 0x47),
+)
+
+
+class _MSG(ctypes.Structure):
+    _fields_ = [
+        ("hwnd", wintypes.HWND),
+        ("message", wintypes.UINT),
+        ("wParam", wintypes.WPARAM),
+        ("lParam", wintypes.LPARAM),
+        ("time", wintypes.DWORD),
+        ("pt_x", ctypes.c_long),
+        ("pt_y", ctypes.c_long),
+    ]
+
+
+class _POWERBROADCAST_SETTING(ctypes.Structure):
+    """Prefix of POWERBROADCAST_SETTING; for GUID_CONSOLE_DISPLAY_STATE the
+    variable `Data` payload is a single DWORD (DataLength == 4)."""
+    _fields_ = [
+        ("PowerSetting", _GUID),
+        ("DataLength", wintypes.DWORD),
+        ("Data", wintypes.DWORD),
+    ]
+
+
+_user32 = ctypes.WinDLL("user32", use_last_error=True)
+_user32.RegisterPowerSettingNotification.argtypes = [
+    wintypes.HANDLE, ctypes.c_void_p, wintypes.DWORD]
+_user32.RegisterPowerSettingNotification.restype = wintypes.HANDLE
+_user32.UnregisterPowerSettingNotification.argtypes = [wintypes.HANDLE]
+_user32.UnregisterPowerSettingNotification.restype = wintypes.BOOL
+
+
+class DisplayWakeListener(BaseWidget):
+
+    woke = QtCore.Signal()
+
+    def __init__(self, parent: QWidget | None) -> None:
+        super().__init__(parent)
+        # Hidden top-level tool window: exists solely so the OS has an HWND
+        # to deliver WM_POWERBROADCAST to. Never shown.
+        self.setWindowFlags(Qt.Tool | Qt.FramelessWindowHint)
+        self._notify_handle: int | None = None
+        # Assume displays are on at startup so an initial "on" broadcast
+        # isn't mistaken for a wake transition.
+        self._display_on = True
+
+        logging.info("Starting display wake listener (WM_POWERBROADCAST)")
+        self._register_for_notifications()
+
+    def _register_for_notifications(self) -> None:
+        hwnd = int(self.winId())
+        handle = _user32.RegisterPowerSettingNotification(
+            wintypes.HANDLE(hwnd),
+            ctypes.byref(GUID_CONSOLE_DISPLAY_STATE),
+            DEVICE_NOTIFY_WINDOW_HANDLE)
+        if not handle:
+            err = ctypes.get_last_error()
+            raise OSError(err, f"RegisterPowerSettingNotification failed (GetLastError={err})")
+        self._notify_handle = handle
+
+    def nativeEvent(self, eventType, message):
+        if eventType == b"windows_generic_MSG":
+            if self._handle_power_message(int(message)):
+                self.woke.emit()
+        return False, 0
+
+    def _handle_power_message(self, msg_ptr: int) -> bool:
+        """Return True when the message represents a display/system wake we
+        should re-assert brightness for, False otherwise."""
+        msg = _MSG.from_address(msg_ptr)
+        if msg.message != WM_POWERBROADCAST:
+            return False
+        wparam = int(msg.wParam)
+        if wparam in (PBT_APMRESUMEAUTOMATIC, PBT_APMRESUMESUSPEND):
+            return True
+        if wparam != PBT_POWERSETTINGCHANGE or not msg.lParam:
+            return False
+        setting = _POWERBROADCAST_SETTING.from_address(msg.lParam)
+        if bytes(setting.PowerSetting) != bytes(GUID_CONSOLE_DISPLAY_STATE):
+            return False
+        display_on = setting.Data == DISPLAY_STATE_ON
+        was_on = self._display_on
+        self._display_on = display_on
+        # Only a genuine off/dimmed -> on transition is a wake.
+        return display_on and not was_on
+
+    def closeEvent(self, event):
+        if self._notify_handle:
+            try:
+                _user32.UnregisterPowerSettingNotification(self._notify_handle)
+            except Exception:
+                logging.exception("UnregisterPowerSettingNotification failed")
+            self._notify_handle = None
+        event.accept()

--- a/swiss_windows_knife/plugins/display_image_tuner/image_tuner_plugin.py
+++ b/swiss_windows_knife/plugins/display_image_tuner/image_tuner_plugin.py
@@ -14,6 +14,7 @@ from ...base.monitor_runner import runner
 from ...base.user_settings import UserSettings
 from .curve import compute_keyframe_value
 from .display_tuning_panel import DisplayTuningConfigPanel
+from .display_wake_listener import DisplayWakeListener
 from .sun_strength_notifier import SunStrengthNotifier, find_sun_events
 
 TICK_MS = 1000
@@ -43,11 +44,18 @@ class DisplayImageTunerPlugin(BaseWidget):
 
         self._last_emitted: dict[str, int | None] = {'brightness': None, 'contrast': None}
         self._needs_retry: dict[str, bool] = {'brightness': False, 'contrast': False}
+        # When set, the next apply for the axis writes unconditionally,
+        # bypassing the get_luminance() dedup. Set on display wake (monitors
+        # may report a stale value after a DDC-resetting power-cycle) and
+        # kept across retries until an apply lands.
+        self._force_next: dict[str, bool] = {'brightness': False, 'contrast': False}
         self._sun_events_cache_day: date | None = None
         self._sun_events_cache: tuple[float | None, float | None] = (None, None)
 
         self.brightness_changed.connect(self.change_monitor_brightness)
         self.contrast_changed.connect(self.change_monitor_contrast)
+
+        self._wake_listener: DisplayWakeListener | None = None
 
         self._set_health(HealthState.OK, self._mode_message())
 
@@ -55,6 +63,7 @@ class DisplayImageTunerPlugin(BaseWidget):
         self._tick_timer.timeout.connect(self._tick)
         if self.is_enabled():
             self._tick_timer.start(TICK_MS)
+            self._start_wake_listener()
 
     def _mode_message(self) -> str:
         b = self.user_settings.get('brightness', int)
@@ -146,9 +155,9 @@ class DisplayImageTunerPlugin(BaseWidget):
         return self._sun_events_cache
 
     def change_monitor_brightness(self, brightness):
-        runner().submit(self._apply_brightness, brightness)
+        runner().submit(self._apply_brightness, brightness, self._force_next['brightness'])
 
-    def _apply_brightness(self, brightness):
+    def _apply_brightness(self, brightness, force=False):
         try:
             monitors = list(enumerate(monitorcontrol.get_monitors()))
         except (ValueError, monitorcontrol.VCPError) as e:
@@ -158,7 +167,7 @@ class DisplayImageTunerPlugin(BaseWidget):
         for i, monitor in monitors:
             try:
                 with monitor:
-                    if monitor.get_luminance() != brightness:
+                    if force or monitor.get_luminance() != brightness:
                         monitor.set_luminance(brightness)
                         logging.info(f"Setting brightness to {brightness} on monitor {i}")
             except (ValueError, monitorcontrol.VCPError) as e:
@@ -169,12 +178,13 @@ class DisplayImageTunerPlugin(BaseWidget):
         if error is not None:
             self._on_apply_failed('brightness', error)
         else:
+            self._force_next['brightness'] = False
             self._set_health(HealthState.OK, self._mode_message())
 
     def change_monitor_contrast(self, contrast):
-        runner().submit(self._apply_contrast, contrast)
+        runner().submit(self._apply_contrast, contrast, self._force_next['contrast'])
 
-    def _apply_contrast(self, contrast):
+    def _apply_contrast(self, contrast, force=False):
         try:
             monitors = list(enumerate(monitorcontrol.get_monitors()))
         except (ValueError, monitorcontrol.VCPError) as e:
@@ -184,7 +194,7 @@ class DisplayImageTunerPlugin(BaseWidget):
         for i, monitor in monitors:
             try:
                 with monitor:
-                    if monitor.get_contrast() != contrast:
+                    if force or monitor.get_contrast() != contrast:
                         monitor.set_contrast(contrast)
                         logging.info(f"Setting contrast to {contrast} on monitor {i}")
             except (ValueError, monitorcontrol.VCPError) as e:
@@ -193,6 +203,7 @@ class DisplayImageTunerPlugin(BaseWidget):
         if error is not None:
             self._on_apply_failed('contrast', error)
         else:
+            self._force_next['contrast'] = False
             self._set_health(HealthState.OK, self._mode_message())
 
     def _on_apply_failed(self, axis: str, error: Exception) -> None:
@@ -200,9 +211,46 @@ class DisplayImageTunerPlugin(BaseWidget):
         # and clear the auto dedup cache so a never-applied value isn't
         # mistaken for already-on-screen. Otherwise a transient VCP error
         # (e.g. a monitor still waking) leaves it at its old value forever.
+        # _force_next is left set so the retry keeps forcing until it lands.
         self._needs_retry[axis] = True
         self._last_emitted[axis] = None
         self._set_health(HealthState.WARNING, f"Monitor error: {error}")
+
+    def _desired_value(self, axis: str) -> int:
+        manual = self.user_settings.get(axis, int)
+        if manual is not None:
+            return manual
+        return max(0, min(100, int(round(self._auto_target(axis)))))
+
+    def _start_wake_listener(self) -> None:
+        if self._wake_listener is not None:
+            return
+        try:
+            self._wake_listener = DisplayWakeListener(self)
+        except Exception:
+            # A missing wake listener only forfeits the on-wake re-assert;
+            # the periodic tick and retry path still work. Don't fail the
+            # whole plugin over it.
+            logging.exception("Failed to start display wake listener")
+            return
+        self._wake_listener.woke.connect(self._on_display_woke)
+
+    def _stop_wake_listener(self) -> None:
+        if self._wake_listener is not None:
+            self._wake_listener.close()
+            self._wake_listener = None
+
+    @Slot()
+    def _on_display_woke(self) -> None:
+        if not self.is_enabled():
+            return
+        logging.info("Display woke — re-asserting brightness and contrast")
+        for axis in ('brightness', 'contrast'):
+            value = self._desired_value(axis)
+            self._force_next[axis] = True
+            self._needs_retry[axis] = False
+            self._last_emitted[axis] = value
+            getattr(self, f'{axis}_changed').emit(value)
 
     def create_value_control_menu(self, title, axis, manual_slot, automatic_slot) -> QMenu:
         menu = QMenu(title, self)
@@ -271,10 +319,13 @@ class DisplayImageTunerPlugin(BaseWidget):
         if status:
             if not self._tick_timer.isActive():
                 self._tick_timer.start(TICK_MS)
+            self._start_wake_listener()
         else:
             self._tick_timer.stop()
+            self._stop_wake_listener()
 
     def closeEvent(self, event):
         self._tick_timer.stop()
+        self._stop_wake_listener()
         self.sun_strength_plugin.close()
         event.accept()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,20 @@ def fake_user_settings(monkeypatch):
     return fake
 
 
+@pytest.fixture(autouse=True)
+def stub_display_wake_listener(monkeypatch):
+    """Keep tests from registering a real Win32 power-setting notification.
+
+    The display tuner spins up a `DisplayWakeListener` on construction; its
+    `_register_for_notifications` calls into user32. Stub it so building the
+    plugin stays hermetic (the listener QWidget itself is harmless)."""
+    from swiss_windows_knife.plugins.display_image_tuner.display_wake_listener import (
+        DisplayWakeListener,
+    )
+    monkeypatch.setattr(
+        DisplayWakeListener, "_register_for_notifications", lambda self: None)
+
+
 @pytest.fixture
 def silent_messagebox(monkeypatch):
     """Suppress QMessageBox modals so apply()-style validation can run headless."""

--- a/tests/test_display_image_tuner_health.py
+++ b/tests/test_display_image_tuner_health.py
@@ -44,9 +44,9 @@ def _failing_monitor():
     cm.__enter__ = lambda self: self
     cm.__exit__ = lambda self, exc_type, exc, tb: None
     cm.get_luminance = MagicMock(side_effect=monitorcontrol.VCPError("asleep"))
-    cm.set_luminance = MagicMock()
+    cm.set_luminance = MagicMock(side_effect=monitorcontrol.VCPError("asleep"))
     cm.get_contrast = MagicMock(side_effect=monitorcontrol.VCPError("asleep"))
-    cm.set_contrast = MagicMock()
+    cm.set_contrast = MagicMock(side_effect=monitorcontrol.VCPError("asleep"))
     return cm
 
 
@@ -145,3 +145,74 @@ def test_manual_contrast_retries_after_failure(plugin, fake_user_settings):
     plugin._needs_retry['contrast'] = True
     plugin._tick()
     assert received == [80]
+
+
+def test_force_apply_writes_even_when_value_matches(plugin):
+    # Wake path: the monitor reports the target value (stale after a DDC
+    # reset), so the normal dedup would skip — force must write anyway.
+    mon = _stub_monitor(50)
+    with patch("monitorcontrol.get_monitors", return_value=[mon]):
+        plugin._apply_brightness(50, force=True)
+    mon.set_luminance.assert_called_once_with(50)
+
+
+def test_non_force_apply_skips_when_value_matches(plugin):
+    mon = _stub_monitor(50)
+    with patch("monitorcontrol.get_monitors", return_value=[mon]):
+        plugin._apply_brightness(50)
+    mon.set_luminance.assert_not_called()
+
+
+def test_force_cleared_after_successful_apply(plugin):
+    plugin._force_next['brightness'] = True
+    with patch("monitorcontrol.get_monitors", return_value=[_stub_monitor(50)]):
+        plugin._apply_brightness(50, force=True)
+    assert plugin._force_next['brightness'] is False
+
+
+def test_force_retained_after_failed_apply(plugin):
+    # If the forced write fails (monitor still waking), keep forcing so the
+    # retry doesn't fall back to the dedup-skipping normal path.
+    plugin._force_next['brightness'] = True
+    with patch("monitorcontrol.get_monitors", return_value=[_failing_monitor()]):
+        plugin._apply_brightness(50, force=True)
+    assert plugin._force_next['brightness'] is True
+    assert plugin._needs_retry['brightness'] is True
+
+
+def test_display_woke_forces_reapply_of_both_axes(plugin, fake_user_settings):
+    fake_user_settings.set('brightness', 30)
+    fake_user_settings.set('contrast', 70)
+    plugin.brightness_changed.disconnect(plugin.change_monitor_brightness)
+    plugin.contrast_changed.disconnect(plugin.change_monitor_contrast)
+    b_vals: list[int] = []
+    c_vals: list[int] = []
+    plugin.brightness_changed.connect(b_vals.append)
+    plugin.contrast_changed.connect(c_vals.append)
+
+    plugin._on_display_woke()
+
+    assert b_vals == [30] and c_vals == [70]
+    assert plugin._force_next['brightness'] is True
+    assert plugin._force_next['contrast'] is True
+
+
+def test_change_monitor_brightness_passes_force_flag(plugin):
+    plugin._force_next['brightness'] = True
+    module = "swiss_windows_knife.plugins.display_image_tuner.image_tuner_plugin"
+    with patch(f"{module}.runner") as mock_runner:
+        plugin.change_monitor_brightness(50)
+    mock_runner().submit.assert_called_once_with(plugin._apply_brightness, 50, True)
+
+
+def test_display_woke_noop_when_disabled(qtbot, fake_user_settings):
+    fake_user_settings.set('plugin_enabled_DisplayImageTunerPlugin', False)
+    from swiss_windows_knife.plugins.display_image_tuner.image_tuner_plugin import DisplayImageTunerPlugin
+    p = DisplayImageTunerPlugin(None)
+    qtbot.addWidget(p)
+    p.brightness_changed.disconnect(p.change_monitor_brightness)
+    received: list[int] = []
+    p.brightness_changed.connect(received.append)
+
+    p._on_display_woke()
+    assert received == []

--- a/tests/test_display_wake_listener.py
+++ b/tests/test_display_wake_listener.py
@@ -1,0 +1,137 @@
+"""Coverage for the WM_POWERBROADCAST-based display wake listener.
+
+The display tuner re-asserts brightness/contrast when `DisplayWakeListener`
+emits `woke`. That must fire on a genuine monitor off->on transition (DPMS)
+and on system resume, but not on redundant "on" broadcasts or unrelated
+power settings.
+"""
+import ctypes
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _build_msg(wparam: int, lparam: int, message: int | None = None):
+    from swiss_windows_knife.plugins.display_image_tuner.display_wake_listener import (
+        _MSG,
+        WM_POWERBROADCAST,
+    )
+    msg = _MSG()
+    msg.message = WM_POWERBROADCAST if message is None else message
+    msg.wParam = wparam
+    msg.lParam = lparam
+    return msg
+
+
+def _build_display_setting(data: int) -> ctypes.Array:
+    """Build a POWERBROADCAST_SETTING carrying GUID_CONSOLE_DISPLAY_STATE
+    with `data` as the DWORD payload. Returns the backing buffer (keep a
+    reference; lParam points into it)."""
+    from swiss_windows_knife.plugins.display_image_tuner.display_wake_listener import (
+        _POWERBROADCAST_SETTING,
+        GUID_CONSOLE_DISPLAY_STATE,
+    )
+    buf = (ctypes.c_ubyte * ctypes.sizeof(_POWERBROADCAST_SETTING))()
+    setting = _POWERBROADCAST_SETTING.from_address(ctypes.addressof(buf))
+    setting.PowerSetting = GUID_CONSOLE_DISPLAY_STATE
+    setting.DataLength = 4
+    setting.Data = data
+    return buf
+
+
+@pytest.fixture
+def listener(qtbot):
+    from swiss_windows_knife.plugins.display_image_tuner.display_wake_listener import (
+        DisplayWakeListener,
+    )
+    # _register_for_notifications is stubbed by the autouse conftest fixture.
+    listener = DisplayWakeListener(parent=None)
+    qtbot.addWidget(listener)
+    return listener
+
+
+def test_ignores_non_powerbroadcast(listener):
+    msg = _build_msg(wparam=0, lparam=0, message=0x0001)
+    assert listener._handle_power_message(ctypes.addressof(msg)) is False
+
+
+def test_system_resume_automatic_is_wake(listener):
+    from swiss_windows_knife.plugins.display_image_tuner.display_wake_listener import (
+        PBT_APMRESUMEAUTOMATIC,
+    )
+    msg = _build_msg(wparam=PBT_APMRESUMEAUTOMATIC, lparam=0)
+    assert listener._handle_power_message(ctypes.addressof(msg)) is True
+
+
+def test_display_off_then_on_is_wake(listener):
+    from swiss_windows_knife.plugins.display_image_tuner.display_wake_listener import (
+        DISPLAY_STATE_OFF,
+        DISPLAY_STATE_ON,
+        PBT_POWERSETTINGCHANGE,
+    )
+    off = _build_display_setting(DISPLAY_STATE_OFF)
+    off_msg = _build_msg(wparam=PBT_POWERSETTINGCHANGE, lparam=ctypes.addressof(off))
+    assert listener._handle_power_message(ctypes.addressof(off_msg)) is False
+
+    on = _build_display_setting(DISPLAY_STATE_ON)
+    on_msg = _build_msg(wparam=PBT_POWERSETTINGCHANGE, lparam=ctypes.addressof(on))
+    assert listener._handle_power_message(ctypes.addressof(on_msg)) is True
+
+
+def test_display_on_when_already_on_is_not_wake(listener):
+    from swiss_windows_knife.plugins.display_image_tuner.display_wake_listener import (
+        DISPLAY_STATE_ON,
+        PBT_POWERSETTINGCHANGE,
+    )
+    # Startup assumes displays are on; a redundant "on" is no transition.
+    on = _build_display_setting(DISPLAY_STATE_ON)
+    on_msg = _build_msg(wparam=PBT_POWERSETTINGCHANGE, lparam=ctypes.addressof(on))
+    assert listener._handle_power_message(ctypes.addressof(on_msg)) is False
+
+
+def test_wrong_power_setting_guid_ignored(listener):
+    from swiss_windows_knife.plugins.display_image_tuner.display_wake_listener import (
+        _POWERBROADCAST_SETTING,
+        PBT_POWERSETTINGCHANGE,
+    )
+    buf = (ctypes.c_ubyte * ctypes.sizeof(_POWERBROADCAST_SETTING))()
+    setting = _POWERBROADCAST_SETTING.from_address(ctypes.addressof(buf))
+    setting.PowerSetting.Data1 = 0xDEADBEEF  # not GUID_CONSOLE_DISPLAY_STATE
+    setting.DataLength = 4
+    setting.Data = 1
+    msg = _build_msg(wparam=PBT_POWERSETTINGCHANGE, lparam=ctypes.addressof(buf))
+    assert listener._handle_power_message(ctypes.addressof(msg)) is False
+
+
+def test_native_event_emits_woke_on_resume(qtbot, listener):
+    from swiss_windows_knife.plugins.display_image_tuner.display_wake_listener import (
+        PBT_APMRESUMEAUTOMATIC,
+    )
+    msg = _build_msg(wparam=PBT_APMRESUMEAUTOMATIC, lparam=0)
+    with qtbot.waitSignal(listener.woke, timeout=500):
+        handled, result = listener.nativeEvent(b"windows_generic_MSG", ctypes.addressof(msg))
+    assert handled is False
+    assert result == 0
+
+
+def test_native_event_ignores_non_windows_event_types(listener):
+    handled, result = listener.nativeEvent(b"xcb_generic_event_t", 0)
+    assert handled is False
+    assert result == 0
+
+
+def test_close_event_unregisters(qtbot, monkeypatch):
+    from swiss_windows_knife.plugins.display_image_tuner import display_wake_listener as m
+
+    fake_user32 = MagicMock()
+    monkeypatch.setattr(m, "_user32", fake_user32)
+    listener = m.DisplayWakeListener(parent=None)
+    qtbot.addWidget(listener)
+    listener._notify_handle = 0xABCD1234
+
+    event = MagicMock()
+    listener.closeEvent(event)
+
+    fake_user32.UnregisterPowerSettingNotification.assert_called_once_with(0xABCD1234)
+    assert listener._notify_handle is None
+    event.accept.assert_called_once()


### PR DESCRIPTION
Re-lands Part 3 of the suspend/wake brightness work. The original PR (#32) was stacked on #31's branch and got merged into that branch *after* #31 had already merged to `main`, so these changes never actually reached `main`. This branch is the same commit cherry-picked cleanly onto current `main`.

## Why

#31 fixed the case where one monitor's DDC isn't ready on wake. This handles a separate hardware quirk: some monitors **reset their DDC luminance to the onboard OSD value on a DPMS power-cycle** while `get_luminance()` still returns the *old* value. The `get_luminance() != target` dedup then skips the corrective write, so the panel stays visibly wrong after waking even though both monitors are reachable.

## What

- **`display_wake_listener.py`** — a new `DisplayWakeListener`, a hidden top-level window that subscribes via `RegisterPowerSettingNotification` to `WM_POWERBROADCAST`: `GUID_CONSOLE_DISPLAY_STATE` off/dimmed→on (monitors waking on mouse move) and `PBT_APMRESUMEAUTOMATIC`/`PBT_APMRESUMESUSPEND` (system resume). Tracks display state so a redundant "on" broadcast isn't treated as a wake; emits `woke`.
- **`image_tuner_plugin.py`** — on `woke`, re-apply both axes with a `force` flag that bypasses the `get_luminance()` dedup. The flag is kept across retries until an apply lands, so a still-waking monitor keeps being force-written instead of falling back to the dedup-skipping path once it recovers. Listener lifecycle is tied to the plugin's enabled state; a registration failure only forfeits the on-wake re-assert (tick + retry still work).

## Tests

- `test_display_wake_listener.py`: message parsing (resume, off→on transition, redundant-on no-op, wrong GUID, non-powerbroadcast), `woke` emission, unregister-on-close.
- Plugin tests: forced write bypasses dedup, non-forced still dedups, force cleared on success / retained on failure, wake forces both axes, `change_monitor_*` propagates the flag, no-op when disabled.
- An autouse conftest fixture stubs the Win32 registration so building the plugin stays hermetic.
- Full suite: **337 passed**; `ruff check` clean. Cherry-picked onto current `main` with no conflicts.

Supersedes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)